### PR TITLE
fix(pre-commit): repair makefile-check hook indentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
   - repo: https://github.com/chrysa/pre-commit-tools
     rev: v0.1.1-94
     hooks:
-    - id: makefile-check
+      - id: makefile-check
       - exclude: ^(\.github/|workflows/|templates/)
         id: yaml-sorter
       - id: json-sorter


### PR DESCRIPTION
## Problem
The `makefile-check` hook (wired at rev `v0.1.1-94`) was inserted one indentation level shallower than its sibling hooks under the `chrysa/pre-commit-tools` repo. That made `.pre-commit-config.yaml` invalid YAML — pre-commit cannot load the config, so every commit needs `--no-verify` and the release-gated lint replay cannot run.

## Fix
Realign the `- id: makefile-check` line to match its sibling hooks' indentation. The config now loads (validated with `yaml.safe_load`). No hook behavior change.

Part of an org-wide repair (31 repos affected by the same wiring defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
