### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.chrysa/STANDARDS.md
+++ b/.chrysa/STANDARDS.md
@@ -1,0 +1,92 @@
+<!--
+  CHRYSA TRANSVERSE STANDARDS — MANAGED FILE, DO NOT EDIT HERE.
+  Source of truth: chrysa/shared-standards/standards/STANDARDS.chrysa.md
+  Distributed to each repo as .chrysa/STANDARDS.md by the distribute-standards workflow.
+  Local CLAUDE.md imports it via `@.chrysa/STANDARDS.md`. Any manual edit will be
+  overwritten on the next sync — change the source repo and let the PR flow back.
+-->
+
+# chrysa — Transverse Standards
+
+These conventions are identical across every chrysa repo. Repo-specific rules live in the
+local `CLAUDE.md`; this file is the shared baseline imported by it.
+
+## Cross-cutting stack (settled ADRs — do not relitigate)
+
+| Layer            | Decision                                                        |
+|------------------|----------------------------------------------------------------|
+| Python           | 3.14 target (CI matrix 3.12 + 3.14)                            |
+| FastAPI          | >= 0.115 + Pydantic v2                                          |
+| Frontend         | React 19 + TypeScript + Vite 6                                  |
+| UI               | shadcn/ui + Tailwind CSS                                        |
+| State            | TanStack Query + Zustand                                        |
+| DB               | PostgreSQL 16 + Redis 7                                         |
+| ORM              | SQLAlchemy 2.0 async + Alembic                                  |
+| Auth             | 4 modes: Google OAuth2 · local (bcrypt) · LDAP · VCS OAuth      |
+| i18n             | react-i18next + fastapi-babel · FR + EN from V1                 |
+| Monorepo         | Turborepo + pnpm workspaces                                     |
+| Versioning       | GitVersion (semantic auto — never bump manually)               |
+| Quality CI       | SonarCloud (0 hotspot · rating A)                               |
+| Linting          | Ruff + Mypy (Python) · ESLint (TS)                             |
+| Pre-commit       | detect-secrets + ruff + mypy + commitlint                      |
+| Error handling   | withErrorHandling() → auto GitHub Issue on failure             |
+| Hosting          | Kimsufi · Docker Compose (local) · Nginx · Certbot · Tailscale  |
+| Monitoring       | Sentry + Uptime Kuma (self-hosted)                            |
+| Agents           | Claude API (primary) · Ollama (fallback)                       |
+| Orchestration    | LangGraph (stateful) · PydanticAI (structured outputs)         |
+
+## Non-negotiable conventions
+
+- **Language**: English — all code, comments, docs, instructions, and config files.
+- **Commits**: Conventional Commits (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`).
+- **Branches**: `feature/`, `bugfix/`, `chore/`, `hotfix/`, `release/` · default branch `develop`.
+- **Merge**: squash merge only · force push forbidden · auto-merge requires CI + owner.
+- **One PR per issue**, scoped tight. Every PR references an issue (`Closes/Fixes/Refs #N`).
+  Exception: label `hotfix`. The `enforce-issue-link` workflow is a blocking status check.
+- **Dark mode** mandatory from V1. **Accessibility** WCAG 2.1 AA.
+
+## Quality gates
+
+- Test coverage **>= 85%** by default. A repo may override upward, never below 80%.
+- Lint warnings: **0**. Mypy clean. SonarCloud rating **A**, 0 security hotspot.
+- Max function lines 50 · max file lines 500 · cyclomatic complexity heuristic <= 10.
+
+## Shared skills (load on demand from shared-standards/.claude/skills/)
+
+- `testing-pytest` — pytest DDD + pytest-mock + constants (writing tests)
+- `dockerfile-multistage` — 4-stage Python 3.14 containers (editing Dockerfile)
+- `api-design` — REST standards + FastAPI patterns (designing endpoints)
+- `async-patterns` — async FastAPI + SQLAlchemy async sessions (async code)
+- `clean-architecture` — FastAPI module/layer structure (adding a feature)
+- `error-handling` — FastAPI errors + Sentry + logging (handling errors)
+- `contract-testing` — library contract / breaking-change tests (@chrysa/* releases)
+- `agent-patterns` — LangGraph + PydanticAI + Claude API (building agents)
+- `ui-ux` — UX/UI/ergonomics + WCAG 2.1 AA + dark mode + i18n (human-facing surfaces)
+
+## Error handling pattern (all automations)
+
+```text
+try:    fn()
+except: gh issue create --title "[chrysa] failure" --label "chrysa-error"
+```
+
+## Observability — Sentry → GitHub issues (norm)
+
+Every status:dev repo ships a Sentry project, and **a new Sentry issue automatically opens a
+GitHub issue** via Sentry's native GitHub integration. No relay, no PAT in the repo — the
+integration owns the link, so a Sentry issue maps to exactly one GitHub issue (no duplicates).
+
+Mechanism: a per-project Sentry **issue alert rule** with
+condition `FirstSeenEventCondition` (a new issue is created) and action
+`GitHubCreateTicketAction` targeting `chrysa/<repo>`, labels `sentry`, `bug`.
+Provision it across all projects with
+`shared-standards/scripts/sentry-github-issues.sh` (idempotent, `--dry-run` first).
+
+Per-project activation checklist:
+
+1. Org GitHub integration installed once in Sentry (Settings → Integrations → GitHub) with
+   access to the chrysa repos.
+2. The repo has a Sentry project whose slug matches the repo name.
+3. The auto-issue alert rule exists (run the provisioning script, or add it in
+   Alerts → Create Alert → Issues → action "Create a GitHub issue").
+4. The GitHub repo has a `sentry` label (CI label sync provides it).

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,53 @@
+---
+description: Create a well-formatted Conventional Commit with atomic-commit analysis
+---
+
+# Command: Commit
+
+Create well-formatted commits following the chrysa Conventional Commits standard.
+
+## Usage
+
+```text
+/commit
+```
+
+## What This Command Does
+
+1. Runs `git status` to see which files are staged.
+2. If nothing is staged, stages all modified and new files with `git add`.
+3. Runs `git diff` to understand the changes.
+4. Analyzes the diff for multiple logical concerns; if found, proposes splitting into
+   several atomic commits and stages them separately.
+5. Writes a Conventional Commit message and commits.
+
+## Commit Convention (chrysa)
+
+Format — see `EXECUTION_STANDARD.md` §3 (source of truth):
+
+```text
+<type>(<scope>): <description>
+```
+
+- `<type>` is one of: `feat`, `fix`, `chore`, `docs`, `ci`, `refactor`, `test`, `perf`.
+- `<scope>` is optional (module or area).
+- Imperative mood, present tense ("add", not "added"). Link issues in the body or footer
+  (`Refs #123`, `Closes #123`).
+- Keep commits **atomic** — one logical concern each.
+
+## Hard Rules
+
+- **NEVER** add a `Co-Authored-By: Claude` / "Generated with Claude Code" trailer.
+- Do not use awattar's `New feature`/`Fix issue` types — chrysa uses the standard spec above.
+- Commit messages are validated by the repo's pre-commit hooks; run `make pre-commit` (Docker)
+  if unsure, never host `pre-commit` directly.
+
+## Agents Used
+
+- **general-code-quality-debugger** — analyze the diff and commit quality.
+- **general-technical-project-lead** — decide commit structure and flag breaking changes.
+
+## References
+
+- Convention: `EXECUTION_STANDARD.md` §3
+- PR format: `@templates/pr-template.md`

--- a/.claude/commands/custom-init.md
+++ b/.claude/commands/custom-init.md
@@ -1,0 +1,74 @@
+---
+description: Generate a comprehensive CLAUDE.md by analyzing the current project
+---
+
+# Command: Custom Init
+
+Generate a well-structured `CLAUDE.md` for the current chrysa project through a phased,
+parallel specialist analysis.
+
+## Usage
+
+```text
+/custom-init
+```
+
+## Relationship to native `/init`
+
+Claude Code ships a built-in `/init`. `/custom-init` reaches the same goal through an
+explicit phased workflow (staged analysis, per-feature detection, versioned stack inventory,
+consistent section order) and seeds the result from `@templates/CLAUDE.md`. Pick whichever
+fits — they are alternatives, not a hierarchy.
+
+## Agents Used
+
+The main session orchestrates and dispatches each pass to the best-fit specialist via the
+Task tool (each in its own context window). Use **general-purpose** only as a fallback.
+
+- **general-solution-architect** — Phase 2 (architecture + stack).
+- **general-backend-developer** — Phase 3 backend passes (auth, domain, data access, comms).
+- **general-devops** — Phase 3 infrastructure + Phase 4 deployment.
+- **general-qa** — Phase 4 testing.
+- **general-code-quality-debugger** — Phase 4 troubleshooting.
+- **general-technical-writer** — Phase 4 docs discovery + Phase 5 assembly.
+
+Phases 0–1 run inline. Phases 2–4 dispatch in **one message** and run concurrently.
+Phase 5 is sequential — it consumes 2–4's outputs.
+
+## Phase 0 — Initialization
+- Validate the cwd is a project root; check for an existing `CLAUDE.md`.
+- Detect available tooling (`git`, `docker`, `make`, language toolchains).
+- Respect `.gitignore`; comprehensive scan.
+
+## Phase 1 — Project Discovery
+- Detect project type from build files (`pyproject.toml`, `package.json`, `go.mod`, `*.csproj`…).
+- Identify primary language/framework; map directory structure; find existing docs.
+
+## Phase 2 — Core Sections *(general-solution-architect)*
+- Overview & Quick Start (from README / package metadata; chrysa Makefile targets — `make install`, `make dev`, `make test`).
+- Architecture (map layout to patterns: DDD, Clean, MVC…; layers and boundaries).
+- Technology Stack (parse dependency files for exact versions; dev vs prod; infra from compose/k8s).
+
+## Phase 3 — Feature Analysis (parallel fan-out)
+One specialist subagent per pass, dispatched together:
+1. **Authentication** *(backend)* — middleware, login routes, token handling.
+2. **Business Domain** *(backend)* — entities, aggregates, services, use cases.
+3. **Data Access** *(backend)* — ORM/repositories, migrations, connection config.
+4. **Communication** *(backend)* — controllers/routes, integrations, messaging.
+5. **Infrastructure** *(devops)* — compose/k8s/Terraform → service map with ports.
+
+## Phase 4 — Additional Sections (parallel fan-out)
+1. **Testing** *(qa)* — frameworks, test counts by type, **Docker/Makefile** test commands.
+2. **Deployment** *(devops)* — CI/CD (`.github/workflows`), deploy scripts, env config.
+3. **Troubleshooting** *(code-quality-debugger)* — `TODO`/`FIXME`/`HACK`, known issues, error patterns.
+4. **Documentation** *(technical-writer)* — OpenAPI/Swagger, markdown docs, external links.
+
+## Phase 5 — Assembly *(general-technical-writer)*
+- Combine outputs; consistent markdown; order by priority; add nav links.
+- Verify commands are executable (Docker/Makefile) and paths correct.
+- Write `CLAUDE.md`. If one exists, back it up as `CLAUDE.md.backup` and reuse accurate content.
+
+## Best Practices
+- Keep `CLAUDE.md` accurate — stale context is worse than none.
+- Reference shared files with the `@` prefix (e.g. `@templates/CLAUDE.md`) instead of duplicating.
+- Document what is non-obvious, not what Claude can already read from the code.

--- a/.claude/commands/help-commands.md
+++ b/.claude/commands/help-commands.md
@@ -1,0 +1,40 @@
+---
+description: Show all available custom commands and how to use them
+---
+
+# Command: Help Commands
+
+List the chrysa custom slash commands and how to use them.
+
+## Usage
+
+```text
+/help-commands
+```
+
+## Available Commands
+
+| Command | Purpose | Agents |
+|---|---|---|
+| `/custom-init` | Generate a structured `CLAUDE.md` via phased parallel analysis | solution-architect, backend, devops, qa, code-quality-debugger, technical-writer |
+| `/commit` | Create a Conventional Commit with atomic-commit analysis | code-quality-debugger, technical-project-lead |
+| `/issue <n>` | Resolve a GitHub issue end-to-end (GitHub Flow) | fullstack, backend, frontend, qa |
+| `/reviewpr <n>` | Review a PR (correctness, OWASP, observability, tests) | code-quality-debugger, technical-project-lead, qa, solution-architect |
+| `/test <scope>` | Run/improve tests — **Docker / Makefile only** | qa, code-quality-debugger, backend, frontend |
+| `/help-commands` | This help | — |
+
+## chrysa Conventions (apply to all commands)
+
+- **Tests/lint/typecheck**: Docker or pre-commit only — never host `pytest`/`ruff`/`tsc`.
+- **Commits**: Conventional Commits (`feat`/`fix`/`chore`/`docs`/`ci`/`refactor`/`test`/`perf`);
+  no Claude co-author trailer. See `EXECUTION_STANDARD.md` §3.
+- **GitHub**: `gh auth switch -u chrysa` before any `gh` command.
+- **Branches**: `feat/<issue-id>-desc`, `fix/<issue-id>-desc`, `chore/`, `docs/`, `ci/`.
+
+## Mechanisms
+
+| Mechanism | Trigger | Best for |
+|---|---|---|
+| **Slash command** | user types `/name` | explicit, on-demand workflows |
+| **Skill** | Claude matches the `description` | conventions that apply automatically (`.claude/skills/`) |
+| **Subagent** | delegated by Claude or a command | heavy focused work in its own context (`.claude/agents/`) |

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,65 @@
+---
+description: Resolve a GitHub issue end-to-end following GitHub Flow
+argument-hint: <issue-number>
+---
+
+# Command: Issue
+
+Analyze and resolve the GitHub issue in $ARGUMENTS following GitHub Flow and chrysa standards.
+
+## Usage
+
+```text
+/issue <issue-number>
+```
+
+## What This Command Does
+
+1. Reads the issue with `gh issue view` (run `gh auth switch -u chrysa` first).
+2. Researches prior art (PRs, codebase, scratchpad) and writes a plan.
+3. Creates a feature branch, implements in small increments, committing via `/commit`.
+4. Tests via Docker / `make test` and opens a PR using the chrysa PR template.
+
+## Agents Used
+
+Selected by issue type: **general-fullstack-developer**, **general-backend-developer**,
+**general-frontend-developer**, **general-qa**, with **general-purpose** for research.
+
+## General
+
+- `gh auth switch -u chrysa` before any `gh` command.
+- Follow GitHub Flow: https://docs.github.com/en/get-started/using-github/github-flow
+- Use `/commit` after each logical step (Conventional Commits, no Claude trailer).
+- Capture context/decisions in a scratchpad so work survives across sessions.
+
+## Workflow
+
+Adapt to the issue type:
+
+- **Standard** (feature): PLAN → CREATE → TEST → DEPLOY
+- **Exploration** (research): Explore → Plan → Confirm → Code → Commit
+- **Test-first** (bug/TDD): Test → Commit → Code → Iterate → Commit
+- **Rapid prototyping** (UI/UX): Code → Screenshot → Iterate
+
+## Plan
+
+1. `gh issue view <n>` — understand the problem; ask clarifying questions if needed.
+2. Search PRs and the codebase for prior art.
+3. Break the issue into small tasks; document the plan in a scratchpad with the issue link.
+
+## Create
+
+1. Branch per `EXECUTION_STANDARD.md` naming: `feat/<issue-id>-short-desc`
+   (`fix/`, `chore/`, `docs/`, `ci/` per type).
+2. Implement in small steps; `/commit` after each.
+
+## Test
+
+- Run tests via **Docker / `make test`** — never host `pytest`/`ruff`/`tsc`.
+- Add tests describing the expected behavior; run the full suite; fix failures before moving on.
+
+## Deploy
+
+Open a PR. The chrysa PR template (`@templates/pr-template.md` /
+`.github/PULL_REQUEST_TEMPLATE.md`) auto-populates — fill Summary, Motivation (link the issue),
+Changes, Testing, Checklist. PR title = the most significant commit message.

--- a/.claude/commands/reviewpr.md
+++ b/.claude/commands/reviewpr.md
@@ -1,0 +1,58 @@
+---
+description: Thoroughly review a GitHub pull request and submit structured feedback
+argument-hint: <pr-number>
+---
+
+# Command: Review PR
+
+Review the GitHub pull request in $ARGUMENTS and submit structured feedback.
+
+## Usage
+
+```text
+/reviewpr <pr-number>
+```
+
+## What This Command Does
+
+1. Fetches PR details, diff and CI status via `gh` (run `gh auth switch -u chrysa` first).
+2. Checks the PR out locally, reviews quality, security and tests.
+3. Documents findings, then submits the review with `gh pr review`.
+4. Monitors author responses and re-reviews.
+
+## Agents Used
+
+- **general-code-quality-debugger** — systematic code review.
+- **general-technical-project-lead** — security assessment + architectural review.
+- **general-qa** — testing validation and edge cases.
+- **general-solution-architect** — architectural decisions and patterns.
+
+## Analyze
+
+1. `gh pr view <n>` — details and description.
+2. `gh pr diff <n>` — full changes.
+3. `gh pr view <n> --json body,title,number` — linked issues; verify acceptance criteria.
+4. `gh pr checks <n>` — CI/CD status.
+
+## Review
+
+Check out with `gh pr checkout <n>`, then assess:
+
+1. **Correctness** — bugs, edge cases, error handling, naming, performance.
+2. **Security (OWASP)** — injection, authz/authn, secret exposure, unsafe deserialization,
+   SSRF. Flag any `.env`/secret leakage. (Aligns with the `review` agent OWASP pass.)
+3. **Observability** — meaningful logging on error paths, metrics on critical paths, no
+   sensitive data in logs.
+4. **Tests** — run via **Docker / `make test`** (never host runners); confirm affected
+   areas are covered.
+5. **Docs** — comments clear; README/docs updated if behavior changed.
+
+## Provide Feedback
+
+1. Document findings with severity (blocking / suggestion) and concrete code suggestions.
+2. Submit via `gh pr review`: approve if all checks pass, else request changes with specifics.
+
+## Iterate
+
+Monitor with `gh pr view --comments`, re-review after changes, approve once resolved.
+Be constructive and specific — critique the code, not the person.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,66 @@
+---
+description: Run and improve the test suite for a given scope (Docker / pre-commit only)
+argument-hint: <file-or-directory | feature | all>
+---
+
+# Command: Test
+
+Run and improve the test suite for the scope in $ARGUMENTS.
+
+## Usage
+
+```text
+/test <file-or-directory>
+/test <feature>
+/test all
+```
+
+## What This Command Does
+
+1. Determines the scope (file, directory, feature, or all).
+2. Runs targeted tests, then the full suite — **always via Docker / Makefile targets**.
+3. Fixes failures and adds missing coverage.
+4. Reports results and commits improvements via `/commit`.
+
+## ⚠️ Execution Rule (NON-NEGOTIABLE)
+
+Tests, lint and type-checks run through **Docker or pre-commit ONLY**. Never invoke host
+`pytest`, `ruff`, `tsc`, `jest`, `vitest`, etc. directly. Use the standard Makefile targets
+(`EXECUTION_STANDARD.md` §1):
+
+- `make test` — unit tests
+- `make test-cov` — tests + coverage (`coverage.xml`)
+- `make lint` / `make typecheck`
+- `make pre-commit` — all pre-commit hooks
+- `make docker-up` / `make docker-down` — service dependencies for integration/e2e
+
+If a target is missing, that is a standards gap — fix the Makefile, do not fall back to host tools.
+
+## Agents Used
+
+- **general-qa** — testing strategy and automation (primary).
+- **general-code-quality-debugger** — debug failing tests.
+- **general-backend-developer** / **general-frontend-developer** — API and UI test coverage.
+
+## Assess
+
+1. Resolve scope from $ARGUMENTS (file/dir → focus there; feature → related specs; `all` → full run).
+2. Check current coverage (`make test-cov`); identify weak areas.
+3. Review existing test patterns for examples and chrysa conventions (`testing-pytest` skill).
+
+## Run
+
+1. Targeted tests first (verbose, fail-fast) via `make test` scoped to the change.
+2. Integration / e2e via `make docker-up` + the project's e2e target if contracts are affected.
+3. Full suite via `make test`; watch for flakiness, timeouts, perf regressions.
+
+## Improve
+
+1. Fix failures (decide test-vs-implementation); commit via `/commit`.
+2. Add tests for uncovered edge cases — happy **and** error paths.
+3. Refactor: remove duplication, clarify descriptions, speed up slow tests.
+
+## Validate & Report
+
+- Re-run to catch flakiness; confirm coverage rose meaningfully (not just numerically).
+- Summarize improvements; if part of a PR, update its Testing section. Commit all changes.

--- a/.claude/skills/agent-patterns/SKILL.md
+++ b/.claude/skills/agent-patterns/SKILL.md
@@ -1,0 +1,211 @@
+# Skill: Agent patterns — LangGraph + Pydantic AI
+
+## When to invoke
+Auto-invoke when: building AI agents, designing LangGraph state machines, defining Pydantic AI tools, writing agent tests, integrating Claude API with stateful workflows (lifeos, ai-aggregator, discord-bot-back).
+
+## 1. State machine design (LangGraph)
+
+### Typed state — always use a dataclass or TypedDict
+```python
+# agent/state.py
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Annotated
+from langgraph.graph import add_messages
+from langchain_core.messages import BaseMessage
+
+@dataclass
+class AgentState:
+    messages: Annotated[list[BaseMessage], add_messages] = field(default_factory=list)
+    tool_calls_remaining: int = 3
+    final_answer: str | None = None
+    error: str | None = None
+```
+
+### Graph construction — explicit node + edge typing
+```python
+# agent/graph.py
+from langgraph.graph import StateGraph, END
+from agent.state import AgentState
+
+def build_graph() -> StateGraph:
+    graph = StateGraph(AgentState)
+    graph.add_node("reason", reason_node)
+    graph.add_node("act", act_node)
+    graph.add_node("respond", respond_node)
+
+    graph.set_entry_point("reason")
+    graph.add_conditional_edges(
+        "reason",
+        should_act,  # returns "act" | END
+        {"act": "act", END: "respond"},
+    )
+    graph.add_edge("act", "reason")
+    graph.add_edge("respond", END)
+    return graph
+
+# Compile with checkpointer for persistence
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+
+async def get_compiled_graph(pool) -> CompiledGraph:
+    checkpointer = AsyncPostgresSaver(pool)
+    await checkpointer.setup()
+    return build_graph().compile(checkpointer=checkpointer)
+```
+
+### Checkpointer rules
+| Environment | Checkpointer |
+|---|---|
+| Production | `AsyncPostgresSaver` (PostgreSQL 16 on cluster) |
+| Tests | `MemorySaver` (no DB required) |
+| Local dev | `MemorySaver` or `AsyncSqliteSaver` |
+
+**Rule**: every agent MUST have a checkpointer configured. Stateless agents lose context on restart.
+
+## 2. Tool definition (Pydantic AI)
+
+### Tool with input validation
+```python
+# agent/tools/search.py
+from pydantic import BaseModel
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.tools import ToolDefinition
+
+class SearchInput(BaseModel):
+    query: str
+    max_results: int = 5
+
+class SearchResult(BaseModel):
+    url: str
+    snippet: str
+
+agent = Agent("claude-3-5-sonnet-latest")
+
+@agent.tool
+async def web_search(ctx: RunContext[None], input: SearchInput) -> list[SearchResult]:
+    """Search the web and return relevant results."""
+    # implementation
+    ...
+```
+
+### Structured output — always use Pydantic models
+```python
+from pydantic import BaseModel
+from pydantic_ai import Agent
+
+class AnalysisResult(BaseModel):
+    summary: str
+    confidence: float
+    sources: list[str]
+
+agent: Agent[None, AnalysisResult] = Agent(
+    "claude-3-5-sonnet-latest",
+    result_type=AnalysisResult,
+    system_prompt="You are an analysis assistant.",
+)
+```
+
+## 3. Agent testing
+
+### Mock LLM calls — never call real APIs in tests
+```python
+# tests/agent/test_graph.py
+import pytest
+from unittest.mock import AsyncMock
+from pydantic_ai.models.test import TestModel
+from langgraph.checkpoint.memory import MemorySaver
+
+from agent.graph import build_graph
+from agent.state import AgentState
+
+@pytest.fixture
+def test_graph():
+    graph = build_graph()
+    return graph.compile(checkpointer=MemorySaver())
+
+
+async def test_agent_returns_final_answer(test_graph) -> None:
+    config = {"configurable": {"thread_id": "test-1"}}
+    result = await test_graph.ainvoke(
+        AgentState(messages=[HumanMessage(content="What is 2+2?")]),
+        config=config,
+    )
+    assert result["final_answer"] is not None
+
+
+# For Pydantic AI — use TestModel to avoid API calls
+async def test_tool_called_with_correct_input() -> None:
+    with agent.override(model=TestModel()):
+        result = await agent.run("search for python async patterns")
+    assert result.data is not None
+```
+
+### Fixture pattern for graph with MemorySaver
+```python
+@pytest.fixture
+def compiled_graph():
+    from langgraph.checkpoint.memory import MemorySaver
+    return build_graph().compile(checkpointer=MemorySaver())
+```
+
+## 4. Error handling in agents
+
+### Always handle tool failures gracefully
+```python
+async def act_node(state: AgentState) -> AgentState:
+    try:
+        result = await call_tool(state)
+        return AgentState(**state.__dict__, messages=[...])
+    except ToolError as exc:
+        remaining = state.tool_calls_remaining - 1
+        if remaining <= 0:
+            return AgentState(**state.__dict__, error=str(exc), final_answer="Unable to complete.")
+        return AgentState(**state.__dict__, tool_calls_remaining=remaining)
+```
+
+### Circuit breaker for external tool calls
+Reuse `api.routing.circuit_breaker.CircuitBreaker` from ai-aggregator for any agent that calls external APIs:
+```python
+from api.routing.circuit_breaker import CircuitBreaker
+
+_breaker = CircuitBreaker(failure_threshold=3, reset_timeout=60.0)
+
+async def safe_tool_call(provider: str, fn, *args, **kwargs):
+    if not _breaker.can_call(provider):
+        raise ToolError(f"Provider {provider} circuit open")
+    try:
+        result = await fn(*args, **kwargs)
+        _breaker.record_success(provider)
+        return result
+    except Exception as exc:
+        _breaker.record_failure(provider)
+        raise ToolError(str(exc)) from exc
+```
+
+## 5. Ollama fallback pattern
+
+Every Claude API call should have an Ollama fallback for local/offline resilience:
+
+```python
+import os
+from pydantic_ai import Agent
+
+def get_model() -> str:
+    if os.getenv("ANTHROPIC_API_KEY"):
+        return "claude-3-5-sonnet-latest"
+    # Fallback to local Ollama
+    return "ollama:llama3"
+
+agent = Agent(get_model(), ...)
+```
+
+## 6. Forbidden patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| Stateless agent (no checkpointer) | Always compile with `MemorySaver` at minimum |
+| Raw string LLM output parsed with regex | Use `result_type=PydanticModel` |
+| Calling real Claude API in tests | Use `TestModel` or `mocker.AsyncMock` |
+| Infinite retry loop in `act_node` | Cap with `tool_calls_remaining` counter in state |
+| Agent tool that does DB access directly | Inject repository via `RunContext` deps |
+| `asyncio.run(agent.run(...))` in a route | Just `await agent.run(...)` — already in async context |

--- a/.claude/skills/api-design/SKILL.md
+++ b/.claude/skills/api-design/SKILL.md
@@ -1,0 +1,89 @@
+# Skill: REST API Design
+
+## When to invoke
+Auto-invoke when: designing new API endpoints, reviewing API responses, adding HTTP status codes, writing FastAPI routes, defining request/response schemas.
+
+## Core rules
+
+### Resource naming
+```
+✅ /api/v1/projects           # plural noun
+✅ /api/v1/projects/{id}      # sub-resource with ID
+✅ /api/v1/projects/{id}/tasks
+❌ /api/v1/getProjects         # no verbs in path
+❌ /api/v1/project             # no singular
+```
+
+### HTTP Methods
+| Method   | URL                  | Action               | Success code  |
+|----------|----------------------|----------------------|---------------|
+| `GET`    | `/resources`         | List                 | `200 OK`      |
+| `GET`    | `/resources/{id}`    | Get one              | `200 OK`      |
+| `POST`   | `/resources`         | Create               | `201 Created` |
+| `PUT`    | `/resources/{id}`    | Full replace         | `200 OK`      |
+| `PATCH`  | `/resources/{id}`    | Partial update       | `200 OK`      |
+| `DELETE` | `/resources/{id}`    | Delete               | `204 No Content` |
+
+### Status codes — always use constants
+```python
+from fastapi import status
+# or
+from http import HTTPStatus
+
+# 2xx
+status.HTTP_200_OK
+status.HTTP_201_CREATED
+status.HTTP_204_NO_CONTENT
+
+# 4xx
+status.HTTP_400_BAD_REQUEST
+status.HTTP_401_UNAUTHORIZED
+status.HTTP_403_FORBIDDEN
+status.HTTP_404_NOT_FOUND
+status.HTTP_409_CONFLICT
+status.HTTP_422_UNPROCESSABLE_ENTITY
+
+# 5xx
+status.HTTP_500_INTERNAL_SERVER_ERROR
+status.HTTP_503_SERVICE_UNAVAILABLE
+```
+**Forbidden**: hardcoded integers (`200`, `404`, `500`)
+
+### Response envelope
+```json
+// Success list
+{ "data": [...], "total": 42, "page": 1 }
+
+// Success single
+{ "data": { "id": "...", ... } }
+
+// Error
+{ "error": { "code": "NOT_FOUND", "message": "Project not found", "detail": null } }
+```
+
+### FastAPI route pattern
+```python
+from fastapi import APIRouter, status
+from .schemas import ProjectCreate, ProjectResponse
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+@router.get("", response_model=list[ProjectResponse], status_code=status.HTTP_200_OK)
+async def list_projects(service: ProjectService = Depends(get_service)):
+    return await service.list()
+
+@router.post("", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
+async def create_project(payload: ProjectCreate, service: ProjectService = Depends(get_service)):
+    return await service.create(payload)
+```
+
+### Security (OWASP Top 10)
+- Auth: `Authorization: Bearer <token>` — never in query params
+- Validate all inputs with Pydantic schemas
+- Rate limit public endpoints
+- CORS: explicit `allow_origins`, never `["*"]` in production
+- No sensitive data in `4xx/5xx` error bodies
+
+### Versioning
+- Version in URL path: `/api/v1/...`
+- Never break existing v1 contracts — add v2 for breaking changes

--- a/.claude/skills/async-patterns/SKILL.md
+++ b/.claude/skills/async-patterns/SKILL.md
@@ -1,0 +1,160 @@
+# Skill: Async patterns for FastAPI + SQLAlchemy 2.0
+
+## When to invoke
+Auto-invoke when: writing async FastAPI endpoints, setting up SQLAlchemy async sessions, writing async tests, using asyncio/anyio, creating background tasks, or designing repository classes.
+
+## 1. DB engine — lifespan pattern (mandatory)
+
+Never use global mutable state for the engine. Always use FastAPI's lifespan:
+
+```python
+# api/main.py
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from api.db.session import create_engine_from_config
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):  # type: ignore[type-arg]
+    engine, session_factory = create_engine_from_config()
+    app.state.session_factory = session_factory
+    yield
+    await engine.dispose()
+
+app = FastAPI(lifespan=lifespan)
+```
+
+```python
+# api/db/session.py
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+def create_engine_from_config(database_url: str | None = None) -> tuple[AsyncEngine, async_sessionmaker[AsyncSession]]:
+    url = database_url or get_url_from_config()
+    engine = create_async_engine(url, echo=False, pool_pre_ping=True)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
+    async with request.app.state.session_factory() as session:
+        yield session
+```
+
+**Why**: A module-level `_engine: AsyncEngine | None = None` singleton creates a shared mutable state across tests. Tests that run in parallel corrupt each other's circuit state.
+
+## 2. Repository pattern
+
+Wrap all DB access in a repository class injected via `Depends`:
+
+```python
+# api/infrastructure/repositories/prompt_repo.py
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from api.db.models import PromptEntry
+
+class PromptRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_key(self, key: str, version: int) -> PromptEntry | None:
+        stmt = select(PromptEntry).where(
+            PromptEntry.key == key,
+            PromptEntry.version == version,
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create(self, entry: PromptEntry) -> PromptEntry:
+        self._session.add(entry)
+        await self._session.commit()
+        await self._session.refresh(entry)
+        return entry
+```
+
+```python
+# Dependency factory
+def get_prompt_repo(session: AsyncSession = Depends(get_session)) -> PromptRepository:
+    return PromptRepository(session)
+```
+
+## 3. Testing async code
+
+### Required setup
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"   # all async test functions run automatically
+```
+
+### DB fixtures use SQLite in-memory
+```python
+# tests/conftest.py
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from api.db.base import Base
+
+@pytest.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+```
+
+### Override get_session in router tests
+```python
+app.dependency_overrides[get_session] = lambda: db_session_fixture
+```
+
+### Mock async providers
+```python
+# Always pytest-mock, never unittest.mock
+async def test_service_calls_provider(mocker: MockerFixture) -> None:
+    mock_provider = mocker.AsyncMock()
+    mock_provider.complete.return_value = ProviderResponse(...)
+    service = CompletionService(provider=mock_provider)
+    await service.complete(request)
+    mock_provider.complete.assert_awaited_once()
+```
+
+## 4. Forbidden patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `global _engine: AsyncEngine \| None = None` | Use lifespan + `app.state` |
+| `asyncio.run(...)` inside FastAPI route | Already in async context — just `await` |
+| `loop.run_until_complete()` anywhere | Use `anyio.from_thread.run_sync()` if crossing thread boundary |
+| `session.execute(stmt).fetchall()` | Use `(await session.execute(stmt)).fetchall()` |
+| `async with AsyncSession(engine)` in each function | Use `get_session` dependency — never create ad-hoc sessions in services |
+| Module-level `async_sessionmaker(engine, ...)` singleton | Always scoped to lifespan |
+
+## 5. Background tasks
+
+```python
+# Prefer FastAPI BackgroundTasks over asyncio.create_task for request-scoped work
+@router.post("/jobs")
+async def create_job(
+    body: JobRequest,
+    background_tasks: BackgroundTasks,
+    service: JobService = Depends(get_job_service),
+) -> JobResponse:
+    job = await service.create(body)
+    background_tasks.add_task(service.process, job.id)
+    return job
+```
+
+For long-running independent tasks (not request-scoped): use a task queue (Redis + arq or Celery), not `asyncio.create_task` — those tasks are lost on restart.
+
+## 6. Connection pool tuning (production)
+
+```python
+# For a single Kimsufi node with multiple services:
+engine = create_async_engine(
+    database_url,
+    pool_size=5,         # connections per worker
+    max_overflow=10,     # burst connections
+    pool_pre_ping=True,  # detect stale connections
+    pool_recycle=3600,   # recycle connections every hour
+)
+```

--- a/.claude/skills/clean-architecture/SKILL.md
+++ b/.claude/skills/clean-architecture/SKILL.md
@@ -1,0 +1,114 @@
+# Skill: Clean Architecture for FastAPI projects
+
+## When to invoke
+Auto-invoke when: creating a new FastAPI module, adding a new domain feature, reviewing existing project structure, deciding where to place new code.
+
+## Layer definitions
+
+Every FastAPI project in the chrysa ecosystem MUST follow this 4-layer structure:
+
+```
+api/
+  routers/          # HTTP boundary — schemas, Depends injection, HTTP errors only
+  services/         # Application layer — orchestrates domain logic + infra
+  domain/           # Pure business logic — no FastAPI, no SQLAlchemy, no I/O
+  infrastructure/   # Adapters — DB repositories, external providers, clients
+  db/               # SQLAlchemy models + session factory (belongs to infrastructure)
+  models/           # Pydantic schemas (request/response + domain value objects)
+```
+
+## Strict import rules
+
+| Layer | May import | Must NOT import |
+|-------|-----------|-----------------|
+| `domain/` | stdlib, pydantic | FastAPI, SQLAlchemy, httpx, any I/O |
+| `services/` | domain, infrastructure interfaces | FastAPI (except type hints), SQLAlchemy models directly |
+| `routers/` | services, models, fastapi | domain (direct), SQLAlchemy, infrastructure |
+| `infrastructure/` | domain interfaces, SQLAlchemy, httpx | FastAPI (except `Request` for deps) |
+
+### Enforced rule
+If a `routers/*.py` file imports from `sqlalchemy` → it belongs in `services/` or `infrastructure/`.
+If a `domain/*.py` file imports from `fastapi` → it belongs in `services/`.
+
+## Required patterns
+
+### Router — HTTP boundary only
+```python
+# api/routers/completions.py
+from fastapi import APIRouter, Depends, HTTPException
+from api.models.completions import CompletionRequest, CompletionResponse
+from api.services.completions import CompletionService, NoProviderAvailableError
+
+router = APIRouter(tags=["completions"])
+
+@router.post("/completions", response_model=CompletionResponse)
+async def create_completion(
+    body: CompletionRequest,
+    service: CompletionService = Depends(get_completion_service),
+) -> CompletionResponse:
+    try:
+        return await service.complete(body)
+    except NoProviderAvailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+```
+
+### Service — orchestration only
+```python
+# api/services/completions.py
+from api.domain.routing import route_request
+from api.infrastructure.providers.base import ProviderGateway
+
+class CompletionService:
+    def __init__(self, gateway: ProviderGateway) -> None:
+        self._gateway = gateway
+
+    async def complete(self, request: CompletionRequest) -> CompletionResponse:
+        provider = route_request(request, self._gateway.available())
+        return await self._gateway.send(provider, request)
+```
+
+### Domain — pure logic, no I/O
+```python
+# api/domain/routing.py
+from dataclasses import dataclass
+from api.domain.provider import ProviderInfo
+
+@dataclass(frozen=True)
+class RouteDecision:
+    provider: str
+    reason: str
+
+def route_request(
+    required_capability: str | None,
+    available_providers: list[ProviderInfo],
+) -> RouteDecision:
+    # Pure function — no async, no DB, no HTTP
+    ...
+```
+
+## Project layout checklist (pre-PR gate)
+
+Before merging any new feature:
+- [ ] No `sqlalchemy` import in `routers/`
+- [ ] No `fastapi` import in `domain/` (except type stubs)
+- [ ] No business logic (if/else on domain objects) in `routers/`
+- [ ] Every new service has a corresponding `tests/services/test_<name>.py`
+- [ ] Every new domain function is a pure function (testable without mocks)
+
+## When to create a new layer file vs. extend existing
+
+- Rule: max 150 lines per service file. If over → split by sub-domain.
+- Rule: domain functions that are called from 2+ services → move to `domain/shared.py`.
+- Anti-pattern: `services/god_service.py` with 500 lines — split by bounded context.
+
+## Refactoring existing routers that violate boundaries
+
+When a router directly imports SQLAlchemy or builds providers:
+1. Extract the logic to a `services/<name>.py`
+2. Add the service as a FastAPI dependency via `Depends()`
+3. Update tests to mock the service, not the infrastructure
+4. The router test should never need a DB fixture
+
+## Reference implementation
+See `chrysa/ai-aggregator/` as the canonical reference.
+Routers: `api/routers/` — Services: `api/services/` — Engine: `api/engine/` (domain equivalent).

--- a/.claude/skills/contract-testing/SKILL.md
+++ b/.claude/skills/contract-testing/SKILL.md
@@ -1,0 +1,131 @@
+# Skill: Consumer-driven contract testing
+
+## When to invoke
+Auto-invoke when: chrysa-lib is about to release a new version, adding a new consumer of `@chrysa/auth` / `@chrysa/ui` / `@chrysa/api-client`, reviewing breaking changes in a library, or designing a new package API.
+
+## 1. Core concept
+
+Consumer-driven contract testing (CDCT) ensures a **provider** (library) never breaks its **consumers** (apps) without being aware of it.
+
+```
+Consumer (dev-nexus, my-fridge)    Provider (chrysa-lib/@chrysa/auth)
+      ↓ declares contract                    ↓ verifies contract
+  contracts/auth.json  ──────────────────→  CI gate on chrysa-lib PR
+```
+
+## 2. chrysa ecosystem layout
+
+```
+chrysa-lib/
+  contracts/
+    consumers/
+      dev-nexus/          ← copy from consumer repo (or git submodule)
+        auth-contract.json
+      my-fridge/
+        auth-contract.json
+```
+
+Each consumer repo declares its contract in `contracts/@chrysa/auth.json`.
+
+## 3. Consumer contract format (Pact v11 — TypeScript)
+
+```typescript
+// contracts/auth.contract.test.ts — lives in the CONSUMER repo
+import { PactV4, MatchersV3 } from "@pact-foundation/pact";
+import { useAuth } from "@chrysa/auth";
+
+const provider = new PactV4({
+  consumer: "dev-nexus",
+  provider: "@chrysa/auth",
+  dir: "contracts",
+});
+
+describe("@chrysa/auth contract", () => {
+  it("AuthConfig.apiBaseUrl is a required string", async () => {
+    await provider
+      .addInteraction()
+      .given("valid auth config")
+      .uponReceiving("a login request")
+      .withRequest({
+        method: "POST",
+        path: "/auth/login",
+        headers: { "Content-Type": "application/json" },
+        body: { email: MatchersV3.string("user@example.com"), password: MatchersV3.string() },
+      })
+      .willRespondWith({
+        status: 200,
+        body: {
+          accessToken: MatchersV3.string(),
+          user: {
+            id: MatchersV3.uuid(),
+            email: MatchersV3.string(),
+            name: MatchersV3.string(),
+          },
+        },
+      })
+      .executeTest(async (mockProvider) => {
+        const { login } = useAuth({ apiBaseUrl: mockProvider.url });
+        const result = await login("user@example.com", "password");
+        expect(result.accessToken).toBeDefined();
+      });
+  });
+});
+```
+
+## 4. Provider verification (chrysa-lib CI)
+
+Add to `chrysa-lib/.github/workflows/ci.yml`:
+
+```yaml
+- name: Verify consumer contracts
+  run: npx pact-provider-verifier \
+    --provider "@chrysa/auth" \
+    --pact-dir contracts/consumers/
+```
+
+Or use the shared workflow:
+```yaml
+uses: chrysa/shared-standards/.github/workflows/contract-testing.yml@main
+with:
+  provider: "@chrysa/auth"
+  language: typescript
+  contracts-path: "contracts/consumers/**/*.json"
+```
+
+## 5. Python packages (schemathesis)
+
+For Python packages (`@chrysa/python/auth`), generate an OpenAPI spec and validate with schemathesis:
+
+```bash
+# Generate spec from FastAPI
+python -c "import json; from api.main import app; print(json.dumps(app.openapi()))" > openapi.json
+
+# Validate consumers' expected schema
+st run openapi.json --checks all --hypothesis-max-examples 50
+```
+
+## 6. Consumer onboarding checklist
+
+When a new project starts consuming a chrysa-lib package:
+- [ ] Add `@pact-foundation/pact` to dev dependencies
+- [ ] Create `contracts/<provider-name>.contract.test.ts`
+- [ ] Run `pact:generate` to produce `contracts/<provider>.json`
+- [ ] Open PR in chrysa-lib adding your contract to `contracts/consumers/<your-app>/`
+- [ ] chrysa-lib CI gate will verify your contract on every PR
+
+## 7. Breaking change protocol
+
+When chrysa-lib wants to change an exported API:
+1. Run `npm run contract:verify` locally against all consumer contracts
+2. If any contract fails → it's a **breaking change** → must bump major version
+3. Notify consumers via GitHub issue before merging
+4. Consumers update their code + regenerate contracts before the new major is released
+
+## 8. Forbidden
+
+| Anti-pattern | Fix |
+|---|---|
+| Releasing chrysa-lib without running contract tests | Contract test CI gate is mandatory from v1.0 |
+| Consumer importing private (`_internal`) exports | Only import from the public `index.ts` |
+| Consumer relying on undocumented types | Open an issue in chrysa-lib to export the type |
+| Pact file committed manually (not generated) | Always generate via `pact:generate` script |

--- a/.claude/skills/dockerfile-multistage/SKILL.md
+++ b/.claude/skills/dockerfile-multistage/SKILL.md
@@ -1,0 +1,87 @@
+# Skill: Dockerfile multi-stage Python 3.14
+
+## When to invoke
+Auto-invoke when: creating or modifying a Dockerfile, updating docker-compose.yml, adding new services, changing Python version, asking about container strategy.
+
+## Pattern
+
+**4 mandatory stages: `base → builder → production → dev`**
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+
+# Stage 1: OS base (shared parent)
+FROM python:3.14-slim AS base
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r appuser && useradd -r -g appuser appuser
+
+# Stage 2: builder — installe les dépendances runtime UNIQUEMENT
+FROM base AS builder
+COPY pyproject.toml .
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir .
+
+# Stage 3: production — IMAGE MINIMALE (pas pip, pas setuptools, pas outils build)
+FROM base AS production
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY src/ src/   # ou api/ selon le projet
+RUN chown -R appuser:appuser /app
+USER appuser
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+# Stage 4: dev — étend builder (pas production), contient tout
+FROM builder AS dev
+RUN pip install --no-cache-dir -e '.[dev]'
+COPY src/ src/
+COPY tests/ tests/
+CMD ["pytest", "tests/", "--cov=app", "--cov-report=term-missing", "-v"]
+```
+
+## Rules
+
+- **Python version**: toujours `python:3.14-slim`
+- **production** repart de `base` (pas de `builder`) → pas de pip dans l'image finale
+- **dev** repart de `builder` (prend tous les steps)
+- L'utilisateur `appuser` est non-root dans **production**
+- **Pas de venv** — les packages vont directement dans `site-packages` du système du conteneur
+
+## docker-compose.yml
+```yaml
+services:
+  backend:
+    build:
+      context: .
+      target: production    # ← image minimale
+
+  backend-test:
+    build:
+      context: .
+      target: dev           # ← tous les steps
+    profiles:
+      - test
+```
+
+## Makefile
+```makefile
+test:
+    docker compose run --rm --no-deps --profile test backend-test
+
+build:
+    docker compose build backend
+
+build-all:
+    docker compose build backend backend-test
+```
+
+## Forbidden
+- `FROM python:3.12` ou toute version < 3.14
+- Installer pip dans le stage `production`
+- Créer ou activer un venv (`virtualenv`, `python -m venv`, `pip install --user`)
+- Copier `pyproject.toml`/`setup.py` dans `production`

--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -1,0 +1,177 @@
+# Skill: Error handling — structured errors, correlation IDs, Sentry
+
+## When to invoke
+Auto-invoke when: adding error handling to a FastAPI endpoint, setting up logging, integrating Sentry, reviewing error responses for consistency, designing exception hierarchies.
+
+## 1. Correlation ID — mandatory on every service
+
+Every FastAPI app MUST include `CorrelationIDMiddleware`. See `chrysa/ai-aggregator/api/middleware/correlation.py` as the reference implementation.
+
+```python
+# api/main.py
+from api.middleware.correlation import CorrelationIDMiddleware
+app.add_middleware(CorrelationIDMiddleware)
+```
+
+Every log record MUST include the correlation ID when inside a request context:
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+@router.post("/completions")
+async def create_completion(request: Request, body: CompletionRequest) -> CompletionResponse:
+    logger.info(
+        "completion request received",
+        extra={"request_id": request.state.request_id, "prompt_len": len(body.prompt)},
+    )
+```
+
+## 2. Exception hierarchy
+
+Define domain exceptions in `api/domain/exceptions.py`, not inline in routers:
+
+```python
+# api/domain/exceptions.py
+class DomainError(Exception):
+    """Base for all domain errors."""
+
+class NotFoundError(DomainError):
+    """Entity not found."""
+
+class ConflictError(DomainError):
+    """Entity already exists / uniqueness violation."""
+
+class ValidationError(DomainError):
+    """Input failed domain-level validation (distinct from Pydantic)."""
+```
+
+Map to HTTP status codes in a single exception handler, not per-endpoint try/except:
+
+```python
+# api/main.py
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from api.domain.exceptions import NotFoundError, ConflictError, ValidationError
+
+@app.exception_handler(NotFoundError)
+async def not_found_handler(request: Request, exc: NotFoundError) -> JSONResponse:
+    return JSONResponse(
+        status_code=404,
+        content={"detail": str(exc), "request_id": request.state.request_id},
+    )
+
+@app.exception_handler(ConflictError)
+async def conflict_handler(request: Request, exc: ConflictError) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content={"detail": str(exc), "request_id": request.state.request_id},
+    )
+```
+
+**Rule**: routers should `raise DomainError` subclasses, never `raise HTTPException` for business errors.
+
+## 3. Structured error response envelope
+
+All error responses MUST follow this JSON shape:
+
+```json
+{
+  "detail": "Human-readable error message",
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "code": "NOT_FOUND"
+}
+```
+
+Pydantic schema:
+```python
+class ErrorResponse(BaseModel):
+    detail: str
+    request_id: str
+    code: str = "INTERNAL_ERROR"
+```
+
+## 4. Sentry integration
+
+```python
+# api/main.py — add after app creation
+import sentry_sdk
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+if dsn := os.getenv("SENTRY_DSN"):
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[FastApiIntegration(), SqlalchemyIntegration()],
+        traces_sample_rate=0.1,   # 10% of requests
+        environment=os.getenv("ENVIRONMENT", "development"),
+        release=os.getenv("APP_VERSION", "0.0.0"),
+    )
+```
+
+### Capture with correlation ID as tag
+```python
+import sentry_sdk
+
+async def some_service_call(request_id: str) -> None:
+    with sentry_sdk.push_scope() as scope:
+        scope.set_tag("request_id", request_id)
+        try:
+            await risky_operation()
+        except Exception:
+            sentry_sdk.capture_exception()
+            raise
+```
+
+## 5. Logging configuration
+
+Use structured logging (JSON) in production:
+
+```python
+# api/logging_config.py
+import logging
+import json
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", None),
+        }
+        return json.dumps(log_record)
+```
+
+```python
+# In lifespan or app startup:
+handler = logging.StreamHandler()
+handler.setFormatter(JSONFormatter())
+logging.root.addHandler(handler)
+logging.root.setLevel(logging.INFO)
+```
+
+## 6. Testing error handling
+
+```python
+async def test_not_found_returns_404_with_request_id(mocker: MockerFixture) -> None:
+    from api.main import app
+    mocker.patch("api.services.registry.get_entry", side_effect=NotFoundError("prompt not found"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/v1/prompts/registry/missing/1")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert "request_id" in body
+    assert body["detail"] == "prompt not found"
+```
+
+## 7. Forbidden patterns
+
+| Anti-pattern | Fix |
+|---|---|
+| `raise HTTPException(status_code=404)` inline in router | `raise NotFoundError(...)` — handler maps to 404 |
+| No `request_id` in error response | Always include via exception handler |
+| `except Exception: pass` (silent swallowing) | Log + re-raise or return structured error |
+| `print(traceback)` in production | Use `logger.exception()` which includes traceback |
+| Sentry DSN hardcoded | Always from `os.getenv("SENTRY_DSN")` |

--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+All commands work via `npx` — no global install required.
+
+## Commands
+
+### analyze — Build or refresh the index
+
+```bash
+npx gitnexus analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+| `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
+
+### status — Check index freshness
+
+```bash
+npx gitnexus status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean — Delete the index
+
+```bash
+npx gitnexus clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki — Generate documentation from the graph
+
+```bash
+npx gitnexus wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list — Show all indexed repos
+
+```bash
+npx gitnexus list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] gitnexus_query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] gitnexus_context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Wrong return value   | `context` on the function → trace callees for data flow    |
+| Intermittent failure | `context` → look for external calls, async deps            |
+| Performance issue    | `context` → find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+
+## Tools
+
+**gitnexus_query** — find code related to error:
+
+```
+gitnexus_query({query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**gitnexus_context** — full context for a suspect:
+
+```
+gitnexus_context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**gitnexus_cypher** — custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. gitnexus_query({query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. gitnexus_context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] gitnexus_query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**gitnexus_query** — find execution flows related to a concept:
+
+```
+gitnexus_query({query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**gitnexus_context** — 360-degree view of a symbol:
+
+```
+gitnexus_context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. gitnexus_query({query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. gitnexus_context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence — execution flows related to a concept |
+| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `detect_changes` | Git-diff impact — what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `list_repos`     | Discover indexed repos                                                   |
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**gitnexus_impact** — the primary tool for symbol blast radius:
+
+```
+gitnexus_impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_detect_changes** — git-diff based impact analysis:
+
+```
+gitnexus_detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**gitnexus_rename** — automated multi-file rename:
+
+```
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**gitnexus_impact** — map all dependents first:
+
+```
+gitnexus_impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**gitnexus_detect_changes** — verify your changes after refactoring:
+
+```
+gitnexus_detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**gitnexus_cypher** — custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | gitnexus_query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review ast_search edits (config.json: dynamic reference!)
+
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. gitnexus_detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/.claude/skills/testing-pytest/SKILL.md
+++ b/.claude/skills/testing-pytest/SKILL.md
@@ -1,0 +1,59 @@
+# Skill: Testing with pytest
+
+## When to invoke
+Auto-invoke when: writing tests, modifying test files, adding new pytest fixtures, debugging test failures, migrating unittest → pytest.
+
+## Rules
+
+### Framework
+- **pytest ONLY** — `unittest.TestCase` is forbidden
+- `pytest-mock` for all mocks: `MockerFixture`, `mocker.patch`, `mocker.AsyncMock`
+- `pytest-asyncio` for async tests: `@pytest.mark.asyncio` (or `asyncio_mode = "auto"` in config)
+- `pytest-cov` for coverage
+
+### Constants
+Every test module references `tests/constants.py` — never hardcode URLs, strings, or IDs:
+```python
+# tests/constants.py
+BASE_URL = "http://testclient"
+ROUTES = {
+    "health": "/health",
+    "completions": "/api/v1/completions",
+}
+def url(route_key: str) -> str:
+    return f"{BASE_URL}{ROUTES[route_key]}"
+```
+
+### Mocking pattern
+```python
+# Always use mocker.AsyncMock for coroutines
+async def test_something(mocker: MockerFixture):
+    mock_service = mocker.AsyncMock(return_value={"result": "ok"})
+    mocker.patch("module.path.service_fn", mock_service)
+    ...
+    mock_service.assert_awaited_once()
+```
+
+### Status codes
+```python
+from fastapi import status
+# or
+from http import HTTPStatus
+
+assert response.status_code == status.HTTP_200_OK
+assert response.status_code == HTTPStatus.CREATED
+```
+
+### File structure
+```
+tests/
+  constants.py       # single source of truth for all test strings/routes
+  conftest.py        # shared fixtures (TestClient, DB session, etc.)
+  test_<domain>.py   # one file per domain module
+```
+
+### Forbidden
+- `import unittest` in test files
+- Hardcoded route strings (`"/api/v1/completions"` inline)
+- Integer status codes (use `status.HTTP_*` or `HTTPStatus.*`)
+- `from unittest.mock import patch` — use `mocker.patch` instead

--- a/.claude/skills/ui-ux/SKILL.md
+++ b/.claude/skills/ui-ux/SKILL.md
@@ -1,0 +1,110 @@
+# Skill: UX / UI / Ergonomics
+
+> Full reference: `shared-standards/docs/UX-UI-GUIDELINES.md`. This module is the actionable,
+> always-on contract loaded when building or reviewing UI.
+> PLACEMENT: copy this file to `shared-standards/.claude/skills/ui-ux/SKILL.md`.
+
+## When to invoke
+Auto-invoke when building or reviewing ANY human-facing surface, not only web:
+- **Web**: React components/pages, Tailwind/shadcn, forms/tables/overlays, dark mode, i18n.
+- **CLI/TUI**: commands, flags, help, output, exit codes.
+- **VS Code extension**: commands, webviews, theming, notifications.
+- **Discord bot**: slash commands, embeds, interactive components.
+- **Desktop/tray**: native apps, system tray, notifications (windows-autonome, floating-agent…).
+- **Game UI (2D)**: HUD, menus, input remapping (Discordium…).
+- **Agent/conversational**: assistant/agent responses (lifeos, my-assistant, coach…).
+- **Alerts/notifications**: briefing/health/state alerts.
+
+Web stack: React 19 + TS + Vite, shadcn/ui + Tailwind, TanStack Query + Zustand, react-i18next.
+
+## Non-negotiable everywhere
+- **Feedback + error recovery** — every action confirms success/failure; errors give cause + next step.
+- **Reversibility** — destructive actions confirmed/undoable; dry-run where feasible.
+- **i18n FR + EN** — no hard-coded user-facing strings (logs stay English).
+- **Accessibility-equivalent** — WCAG 2.1 AA on web; closest equivalent per surface (keyboard, SR, contrast, colorblind, NO_COLOR…).
+- **Dark mode** (web/desktop) — semantic tokens / OS theme, verified contrast.
+- **No noise** — notify only what's actionable; tunable frequency.
+
+## Surface quick rules (see docs/UX-UI-GUIDELINES.md §12)
+- **CLI**: `--help` everywhere · stable flags (`--dry-run/--json/--yes/--quiet`) · errors→stderr · exit codes · progress · honor `NO_COLOR`/non-TTY.
+- **VS Code**: namespaced palette commands · theme color tokens (no hex) · status bar > notifications · no keybind clashes · webviews = full web baseline.
+- **Discord**: slash cmds with descriptions · ephemeral errors · ack <3s (defer) · perms+confirm on admin · label+icon not color · `/help`.
+- **Desktop/tray**: OS conventions · persist window state · honor OS theme · tray Quit always present · actionable, rate-limited notifications · platform a11y API.
+- **Game 2D**: readable HUD · colorblind-safe · pause/settings reachable · input remapping (kbd+pad) · feedback/juice · first-run onboarding · reduced-motion.
+- **Agent**: state capabilities/limits · confirm irreversible/external actions · transparent on uncertainty/failure · concise · FR/EN · respect preferences.
+- **Alerts**: signal>noise · explicit severity (label+icon) · self-contained (what/why/action/where) · dismissible/snoozable · digest over spam.
+
+## Core rules
+
+### Tokens — no magic values
+```tsx
+// ✅ semantic, theme-aware (free dark mode)
+<div className="bg-background text-foreground border border-border" />
+<Button variant="destructive">Delete</Button>
+// ❌ never
+<div className="bg-[#0f172a] text-white" style={{ borderColor: "#e2e8f0" }} />
+```
+- No hard-coded hex / px font sizes / arbitrary spacing. Tailwind 4/8px scale + `--radius` only.
+- Color never the sole carrier of meaning (icon + text for status/errors).
+
+### The four states — always all four
+Every data view handles loading / empty / error / success. A view that only renders
+"success with data" is **incomplete**.
+```tsx
+if (isPending) return <ListSkeleton rows={6} />;
+if (isError)   return <ErrorState onRetry={refetch} message={t("errors.load")} />;
+if (!data.length) return <EmptyState action={<CreateButton />} />;
+return <List items={data} />;
+```
+- Skeleton matching final layout (not a bare spinner) for content loads.
+- Empty state explains why + offers the primary next action.
+- Error state: plain language + Retry. Never a raw stack trace/code.
+
+### Accessibility (WCAG 2.1 AA)
+- Contrast ≥ 4.5:1 text, ≥ 3:1 large text & UI components.
+- Full keyboard operability, logical tab order, no traps.
+- Visible focus everywhere: `focus-visible:ring-2 ring-ring`. Never bare `outline: none`.
+- Prefer semantic HTML; ARIA only to fill gaps and kept in sync.
+- Every input has a real `<Label htmlFor>`; placeholder ≠ label.
+- One `<h1>`/page, ordered headings, landmarks, skip link.
+- `aria-live` for toasts/dynamic updates. `<html lang>` follows locale.
+- Honor `prefers-reduced-motion`.
+- Tooling: `eslint-plugin-jsx-a11y` + automated axe check + **manual keyboard/SR pass (required)**.
+
+### Dark mode
+- `.dark` class on `<html>` + semantic tokens. Default to `prefers-color-scheme`,
+  user override, persist, no flash-of-wrong-theme. Verify contrast in dark separately.
+
+### i18n (FR + EN)
+- All copy via `react-i18next` `t("ns.key")`. No string concatenation; ICU plurals with `{ count }`.
+- Layouts tolerate +30–40% FR expansion. Dates/numbers via `Intl.*`. FR/EN catalogs in lockstep.
+
+### Components
+- shadcn/ui primitives first — keep their ARIA/focus/keyboard intact when extending.
+- One primary action per view (`variant="default"`); `destructive` only for irreversible actions.
+- Overlays: trap focus, `Esc` to close, return focus to trigger, accessible name.
+- Forms: validate on blur/submit, errors via `aria-describedby` + `aria-invalid`, preserve input.
+- Targets ≥ 44px on touch.
+
+### UX copy
+- Plain language, active voice, sentence case. Buttons name the action ("Create project", not "OK").
+- Errors: what happened + what to do next. For deep copy work, defer to `design:ux-copy`.
+
+## Forbidden patterns
+- ❌ Hard-coded colors / px font sizes / arbitrary spacing in components.
+- ❌ User-facing string literals in JSX (must go through i18n).
+- ❌ `outline: none` without a visible replacement.
+- ❌ Placeholder used as the only label.
+- ❌ Data view missing empty/error/loading states.
+- ❌ Color-only status/error indication.
+- ❌ Dark-mode styles assumed correct without contrast verification.
+- ❌ Custom widget reimplementing what a shadcn primitive already does accessibly.
+
+## Definition of Done
+Loading+empty+error+success · dark verified · keyboard pass · SR smoke test · contrast OK ·
+tokens only · FR+EN aligned · responsive 320px→2xl · reduced-motion · jsx-a11y clean ·
+one primary action. Full checklist: `docs/UX-UI-GUIDELINES.md` §11.
+
+## Related Cowork skills
+`design:design-system` · `design:accessibility-review` · `design:ux-copy` ·
+`design:design-critique` · `design:design-handoff`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+---
+# Canonical CI workflow for Python projects (chrysa ecosystem).
+#
+# Usage: copy to .github/workflows/ci.yml. The applier
+# (scripts/apply-repo-standard.sh) substitutes the ${...} placeholders:
+#   pre_commit_hook      import package / source dir       (e.g. django_pytest)
+#   pre_commit_hook tests      ruff sources, space-separated     (e.g. "django_pytest tests")
+#   tests        test dir                          (e.g. tests)
+#   target    repo name                         (e.g. django-pytest)
+#   chrysa_target  SonarCloud project key            (e.g. chrysa_django-pytest)
+#
+# ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it is a copy-to-use
+#    template, not a reusable `uses:` workflow.
+#
+# NOTE: Lint (ruff/mypy/pre-commit) does NOT run here. It lives in pre-commit
+#       (local) and is replayed in CI only at release time via release.yml's
+#       lint gate (chrysa/github-actions/.github/workflows/lint-python.yml).
+#       This CI keeps only tests + sonar, to gate PRs without per-push lint billing.
+#
+# Job names (test / sonar) are the branch-protection required status checks —
+# keep them stable across repos.
+
+name: CI
+
+on:
+    pull_request:
+        branches: [main]
+    push:
+        branches:
+            - main
+            - "feat/**"
+            - "fix/**"
+            - "chore/**"
+            - "ci/**"
+    workflow_dispatch:
+
+permissions:
+    checks: write
+    contents: read
+    pull-requests: write
+    statuses: write
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    test:
+        name: Docker tests
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            - name: Run tests via Docker
+              run: make docker-test
+
+    sonar:
+        name: SonarCloud
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        needs: test
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        permissions:
+            contents: read
+            pull-requests: read
+        steps:
+            - uses: actions/checkout@v6.0.2
+              with:
+                  fetch-depth: 0
+
+            - uses: chrysa/github-actions/sonar-scan-python@v1.0.12
+              with:
+                  python-version: "3.14"
+                  sonar-token: ${{ secrets.SONAR_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  project-key: chrysa_target
+                  organization: chrysa
+                  project-name: target
+                  sources: .
+                  tests: tests
+                  coverage-report: coverage.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md — [PROJECT_NAME]
+
+> Replace [PROJECT_NAME] and all [PLACEHOLDER] values before committing.
+> @[claude-sonnet-4-6]
+
+> **Claude Code**: at session start, read `primer.md` FIRST (current state), then this file (conventions).
+> Also read `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` for code specifications.
+
+## Project
+
+**Name:** [PROJECT_NAME]
+**Stack:** [Python 3.14 / Node.js LTS / React / ...]
+**Purpose:** [One sentence description]
+
+## Conventions
+
+- Language: English — all code, comments, documentation, instructions, and configuration files must be in English.
+- Commits: Conventional Commits (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`)
+- Branch naming: `feature/`, `bugfix/`, `chore/`, `hotfix/`, `release/`
+- Default branch: `develop`
+
+## Standards
+
+- Max function lines: 50
+- Max file lines: 500
+- Max complexity (heuristic): 10
+- Lint warnings: 0
+- Test coverage: [X]%
+
+## Session Workflow
+
+| Step | Command | When |
+|------|---------|------|
+| Start session | `make prepare` or `/prepare` | Always — loads primer + git context |
+| End session | `make hindsight` or `/hindsight` | Always — updates primer + memory |
+| Init memory | `make memory-init` | Once per repo |
+| Export to Obsidian | `make hindsight OBSIDIAN=<path>` | Optional |
+
+**Files:**
+- `primer.md` — current state, next actions, blockers (read before CLAUDE.md)
+- `.claude/memory/` — session, decisions, known-issues, progress (not committed except progress/decisions)
+
+## Setup
+
+```bash
+make install             # Install dependencies
+make memory-init         # Initialize primer.md + .claude/memory/
+make lint                # Run linter
+make test                # Run tests
+make build               # Build (if applicable)
+codegraph init --index . # Build CodeGraph index (run once, never commit .codegraph/)
+/graphify                # Build knowledge graph (run once or /graphify --update; never commit graphify-out/)
+```
+
+## CI
+
+- CI runs on push to `develop`/`main` and on PRs to those branches
+- CI must pass before merging
+- SonarQube analysis is configured in CI (not via sonar-project.properties)
+
+## Repository-specific rules
+
+[Add project-specific rules here. E.g.:]
+- [ ] Describe any project-specific allowlists for secret scanner
+- [ ] Describe custom thresholds vs shared defaults
+- [ ] Note any hooks that are disabled for this repo and why
+
+## Model-specific notes (@[claude-sonnet-4-6])
+
+[Add any rules or instructions that apply only when using a specific model.]
+
+## Skills
+
+Shared skills from `shared-standards/.claude/skills/`:
+- `testing-pytest/SKILL.md` — pytest DDD + pytest-mock + constants (load when writing tests)
+- `dockerfile-multistage/SKILL.md` — 4-stage Python 3.14 containers (load when editing Dockerfile)
+- `api-design/SKILL.md` — REST standards + FastAPI patterns (load when designing endpoints)
+- `ui-ux/SKILL.md` — UX/UI/ergonomics across ALL surfaces (web, CLI, VS Code, Discord, desktop, game, agent) + WCAG 2.1 AA + dark mode + i18n FR+EN (load when building any human-facing surface)
+
+## graphify
+
+For any question about this repo's architecture, structure, components, or how to add/modify/find
+code, your **first tool call must be** to read `graphify-out/GRAPH_REPORT.md` (if it exists).
+
+Triggers: "how do I…", "where is…", "what does … do", "add/modify a <component>",
+"explain the architecture", or anything that depends on how files or classes relate.
+
+After reading the report (and `graphify-out/wiki/index.md` for deep questions), answer from the
+graph. Only read source files when (a) modifying/debugging specific code, (b) the graph lacks
+the needed detail, or (c) the graph is missing or stale.
+
+Type `/graphify` in Copilot Chat to build or update the graph.
+
+<!-- chrysa:standards-import:start -->
+@.chrysa/STANDARDS.md
+<!-- chrysa:standards-import:end -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to pre-commit-hooks-changelog
+# Contributing to target
 
 Thanks for contributing. This repo follows the chrysa
 [Execution Standard](https://github.com/chrysa/shared-standards/blob/main/EXECUTION_STANDARD.md).


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@b2414049112242f33b2a7ad2e1916f772ae13567`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards