### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,79 +3,102 @@ default_language_version:
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-  - repo: local
-    hooks:
-      - id: clean_python
-        name: clean python cache and compiled
-        entry: pyclean .
-        language: system
-        pass_filenames: false
-      - id: hadolint
-        name: Valid Dockerfile
-        description: Lint Dockerfiles with hadolint
-        language: docker_image
-        types:
-          - dockerfile
-        entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3008 --ignore DL3013 --ignore DL3018 --ignore DL4006 --ignore SC2001 --ignore SC2086 --ignore SC2102 -
-      - id: generate-changelog
-        name: generate changelog from folder
-        entry: pre-commit-generate-changelog
-        language: system
-        types:
-          - yaml
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-json
-      - exclude: ^.github/ISSUE_TEMPLATE/
-        id: check-yaml
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: detect-private-key
-      - args:
-          - --branch
-          - main
-        id: no-commit-to-branch
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.49.0
-    hooks:
-      - args:
-          - --fix
-        id: markdownlint
-        stages:
-          - manual
-  - repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-94
-    hooks:
-      - id: makefile-check
-      - exclude: ^(\.github/|workflows/|templates/)
-        id: yaml-sorter
-      - id: json-sorter
-      - id: env-file-check
-      - id: env-example-sync
-      - id: adr-gate
-  # TODO: add detect-duplicated-copilot-instructions after chrysa/pre-commit-tools#163 is merged and released
-  # --- python (all Python repos) ---
-      - id: debugger-detection
-      - id: python-print-detection
-      - id: python-pprint-detection
-        exclude: 'tests?/'
-      - id: no-bare-except
-      - id: python-logger-detection
-      - id: python-unreachable-code
-      - id: no-hardcoded-localhost
-        exclude: 'tests?/|\.test\.|\.spec\.'
-      - id: regression-gate
-        stages: [pre-push]
-      - id: dockerfile-no-latest
-  # --- js/ts (JS/TS repos — remove if not applicable) ---
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.1
-    hooks:
-      - id: gitleaks
-  - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.4.0
-    hooks:
-      - id: conventional-pre-commit
-        stages: [commit-msg]
-        args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
+- repo: local
+  hooks:
+  - id: clean_python
+    name: clean python cache and compiled
+    entry: pyclean .
+    language: system
+    pass_filenames: false
+  - id: hadolint
+    name: Valid Dockerfile
+    description: Lint Dockerfiles with hadolint
+    language: docker_image
+    types:
+    - dockerfile
+    entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3008 --ignore
+      DL3013 --ignore DL3018 --ignore DL4006 --ignore SC2001 --ignore SC2086 --ignore
+      SC2102 -
+  - id: generate-changelog
+    name: generate changelog from folder
+    entry: pre-commit-generate-changelog
+    language: system
+    types:
+    - yaml
+  - id: gitversion-canonical-drift
+    name: GitVersion.yml canonical drift
+    entry: scripts/check-canonical-drift.sh GitVersion.yml templates/GitVersion.yml
+    language: system
+    pass_filenames: false
+    files: ^(GitVersion\.yml|templates/GitVersion\.yml)$
+  - id: cliff-canonical-drift
+    name: cliff.toml canonical drift
+    entry: scripts/check-canonical-drift.sh cliff.toml templates/cliff.toml
+    language: system
+    pass_filenames: false
+    files: ^(cliff\.toml|templates/cliff\.toml)$
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+  - id: check-json
+  - exclude: ^.github/ISSUE_TEMPLATE/
+    id: check-yaml
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: detect-private-key
+  - args:
+    - --branch
+    - main
+    id: no-commit-to-branch
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.49.0
+  hooks:
+  - args:
+    - --fix
+    id: markdownlint
+    stages:
+    - manual
+- repo: https://github.com/chrysa/pre-commit-tools
+  rev: v0.1.1-94
+  hooks:
+  - id: makefile-check
+  - exclude: ^(\.github/|workflows/|templates/)
+    id: yaml-sorter
+  - id: json-sorter
+  - id: env-file-check
+  - id: env-example-sync
+  - id: adr-gate
+  - id: debugger-detection
+  - id: python-print-detection
+  - id: python-pprint-detection
+    exclude: tests?/
+  - id: no-bare-except
+  - id: python-logger-detection
+  - id: python-unreachable-code
+  - id: no-hardcoded-localhost
+    exclude: tests?/|\.test\.|\.spec\.
+  - id: regression-gate
+    stages:
+    - pre-push
+  - id: dockerfile-no-latest
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.1
+  hooks:
+  - id: gitleaks
+- repo: https://github.com/compilerla/conventional-pre-commit
+  rev: v4.4.0
+  hooks:
+  - id: conventional-pre-commit
+    stages:
+    - commit-msg
+    args:
+    - feat
+    - fix
+    - docs
+    - style
+    - refactor
+    - test
+    - chore
+    - perf
+    - revert
+    - ci


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@5292b616e3723f95d2764649fe7b31429497d7ed`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards