### PR TITLE
chore(standards): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+---
+name: Release
+
+on:
+    push:
+        branches: [main, master]
+        paths-ignore:
+            - '**.md'
+            - .github/**
+    workflow_dispatch:
+
+permissions:
+    contents: write
+    pull-requests: read
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        name: Create release
+        steps:
+            - uses: actions/checkout@v6.0.3
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+            - name: Setup GitVersion
+              uses: gittools/actions/gitversion/setup@v4
+              with:
+                  versionSpec: 6.x
+
+            - name: Determine version
+              id: gitversion
+              uses: gittools/actions/gitversion/execute@v4
+
+            - name: Install git-cliff
+              uses: taiki-e/install-action@git-cliff
+
+            - name: Generate changelog
+              id: changelog
+              run: |
+                  CURRENT_TAG="v${{ steps.gitversion.outputs.semVer }}"
+                  git cliff --output CHANGELOG_RELEASE.md --tag "$CURRENT_TAG" 2>/dev/null || \
+                    git cliff --unreleased --output CHANGELOG_RELEASE.md
+                  echo "version=$CURRENT_TAG" >> "$GITHUB_OUTPUT"
+
+            - name: Create tag
+              run: |
+                  git config user.name 'chrysa'
+                  git config user.email 'greau.anthony+chrysa@gmail.com'
+                  git tag "${{ steps.changelog.outputs.version }}" || echo "Tag already exists"
+                  git push origin "${{ steps.changelog.outputs.version }}" || echo "Tag push skipped"
+
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v3
+              with:
+                  tag_name: ${{ steps.changelog.outputs.version }}
+                  name: Release ${{ steps.changelog.outputs.version }}
+                  body_path: CHANGELOG_RELEASE.md
+                  token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes standards-conformance gaps (governance files).

chore(standards): add app-tier release.yml (version + changelog + GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)