### PR TITLE
fix(pre-commit): drop leaked canonical-drift local hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,27 +16,15 @@ repos:
     language: docker_image
     types:
     - dockerfile
-    entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3008 --ignore
-      DL3013 --ignore DL3018 --ignore DL4006 --ignore SC2001 --ignore SC2086 --ignore
-      SC2102 -
+    entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3008 
+      --ignore DL3013 --ignore DL3018 --ignore DL4006 --ignore SC2001 --ignore 
+      SC2086 --ignore SC2102 -
   - id: generate-changelog
     name: generate changelog from folder
     entry: pre-commit-generate-changelog
     language: system
     types:
     - yaml
-  - id: gitversion-canonical-drift
-    name: GitVersion.yml canonical drift
-    entry: scripts/check-canonical-drift.sh GitVersion.yml templates/GitVersion.yml
-    language: system
-    pass_filenames: false
-    files: ^(GitVersion\.yml|templates/GitVersion\.yml)$
-  - id: cliff-canonical-drift
-    name: cliff.toml canonical drift
-    entry: scripts/check-canonical-drift.sh cliff.toml templates/cliff.toml
-    language: system
-    pass_filenames: false
-    files: ^(cliff\.toml|templates/cliff\.toml)$
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:


### PR DESCRIPTION
## Context

This repo's `.pre-commit-config.yaml` carries two `repo: local` hooks —
`gitversion-canonical-drift` and `cliff-canonical-drift` — that leaked from the shared
baseline. They run `scripts/check-canonical-drift.sh` against `templates/` copies that exist
**only in shared-standards**, so here every pre-commit run fails with
`Executable scripts/check-canonical-drift.sh not found`, reddening the `Pre-commit`/`Lint` CI job.

## Change

Remove the leaked `canonical-drift` hooks (and the now-empty `repo: local` block where applicable).
No other hooks touched.

Source fix that prevents re-leak on the next baseline sync: chrysa/shared-standards#131
(`pre-commit-merge.py` no longer distributes `repo: local` hooks).

## Verification

`pre-commit run --all-files` passes after removal (verified on django-query-optimizer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
