### PR TITLE
fix(ci): correct Sonar project key + real sources + bump scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
                   python-version: "3.14"
                   sonar-token: ${{ secrets.SONAR_TOKEN }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  project-key: chrysa_target
+                  project-key: chrysa_pre-commit-hooks-changelog
                   organization: chrysa
-                  project-name: target
-                  sources: .
+                  project-name: pre-commit-hooks-changelog
+                  sources: changelog,helper,pre_commit_hook
                   tests: tests
                   coverage-report: coverage.xml


### PR DESCRIPTION
Sonar placeholder `chrysa_target` + `sources: .`/`tests` double-index (exit 3). Fix: key `chrysa_pre-commit-hooks-changelog`, sources `changelog,helper,pre_commit_hook`, scanner `@v1.1.3`.

Generated with Claude Code