### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,9 +16,9 @@ repos:
     language: docker_image
     types:
     - dockerfile
-    entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3008 
-      --ignore DL3013 --ignore DL3018 --ignore DL4006 --ignore SC2001 --ignore 
-      SC2086 --ignore SC2102 -
+    entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3008 --ignore
+      DL3013 --ignore DL3018 --ignore DL4006 --ignore SC2001 --ignore SC2086 --ignore
+      SC2102 -
   - id: generate-changelog
     name: generate changelog from folder
     entry: pre-commit-generate-changelog
@@ -47,7 +47,7 @@ repos:
     stages:
     - manual
 - repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-94
+  rev: v0.1.1-95
   hooks:
   - id: makefile-check
   - exclude: ^(\.github/|workflows/|templates/)


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@17bdb1674c547355cc156a37a5435a42bc27471f`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards