### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@
 #   pre_commit_hook      import package / source dir       (e.g. django_pytest)
 #   pre_commit_hook tests      ruff sources, space-separated     (e.g. "django_pytest tests")
 #   tests        test dir                          (e.g. tests)
-#   target    repo name                         (e.g. django-pytest)
-#   chrysa_target  SonarCloud project key            (e.g. chrysa_django-pytest)
+#   pre-commit-hooks-changelog    repo name                         (e.g. django-pytest)
+#   chrysa_pre-commit-hooks-changelog  SonarCloud project key            (e.g. chrysa_django-pytest)
 #
 # ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it is a copy-to-use
 #    template, not a reusable `uses:` workflow.
@@ -77,6 +77,6 @@ jobs:
                   project-key: chrysa_pre-commit-hooks-changelog
                   organization: chrysa
                   project-name: pre-commit-hooks-changelog
-                  sources: changelog,helper,pre_commit_hook
+                  sources: pre_commit_hook
                   tests: tests
                   coverage-report: coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to target
+# Contributing to pre-commit-hooks-changelog
 
 Thanks for contributing. This repo follows the chrysa
 [Execution Standard](https://github.com/chrysa/shared-standards/blob/main/EXECUTION_STANDARD.md).


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@94dd8101537b2661a2a9d8eb262b94462220c38d`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards