### PR TITLE
ci: upload coverage.xml so SonarCloud receives it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,18 @@ jobs:
             - name: Run tests via Docker
               run: make docker-test
 
+            # Coverage is generated inside the test job; the sonar job runs on a
+            # separate runner, so the report must travel as an artifact. The name
+            # MUST be test-results-<python-version> — that is exactly what
+            # sonar-scan-python downloads into reports/.
+            - name: Upload coverage report
+              if: always()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: test-results-3.14
+                  path: coverage.xml
+                  if-no-files-found: warn
+
     sonar:
         name: SonarCloud
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -79,4 +91,6 @@ jobs:
                   project-name: pre-commit-hooks-changelog
                   sources: pre_commit_hook
                   tests: tests
-                  coverage-report: coverage.xml
+                  # Downloaded from the test-results-3.14 artifact into reports/
+                  # by the action; matches sonar-scan-python's default path.
+                  coverage-report: reports/coverage.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,13 @@ COPY . /src
 WORKDIR /src
 RUN pip install --quiet --upgrade pip
 
-<<<<<<< HEAD
 FROM base AS application
+# Editable install so coverage records repo-relative paths (pre_commit_hook/...)
+# instead of site-packages paths, which SonarCloud cannot map to source files.
 RUN pip install --quiet --editable .
-=======
-RUN set -x \
- && pip install -e .[pre_commit,push,tests]
->>>>>>> master
 
 FROM application AS pytest
-RUN pip install --quiet .[tests]
+RUN pip install --quiet -e ".[tests]"
 
 FROM application AS documentation
 RUN pip install --quiet .[documentation]

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,13 @@ test-cov: coverage  ## Run tests with coverage (alias)
 docker-up:  ## Start docker compose services
 	@docker compose up -d
 docker-down: down  ## Stop docker compose services (alias)
-docker-test: test  ## Run tests in Docker (alias)
+docker-test: ## Run tests with coverage in Docker; surfaces coverage.xml on host for CI
+	@# Pre-create coverage.xml as a file so the bind-mount maps file->file
+	@# (Docker auto-creates a *directory* for a missing bind source, which
+	@# then makes coverage's open(path,"w") fail). -T disables the pseudo-TTY
+	@# so this also runs in CI / non-interactive contexts.
+	@rm -rf coverage.xml
+	@touch coverage.xml
+	@docker compose run --rm -T pytest bash -c "pytest --cov=pre_commit_hook --cov-branch --cov-config=./setup.cfg --cov-report xml:./coverage.xml --new-first --capture=sys"
 ci: lint typecheck test  ## Run the full local gate (lint + typecheck + test)
 dev: build  ## Build images (no dev server, alias)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
         volumes:
             - *default-app-volume-app
             - ./tests:/src/tests
+            # Surface coverage.xml on the host so CI can upload it to SonarCloud.
+            - ./coverage.xml:/src/coverage.xml
     quality:
         <<: *default-app
         image: generate_changelog_quality:1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,9 @@ skip_covered = true
 
 [coverage:run]
 branch = True
+# Emit repo-relative file paths in coverage.xml so SonarCloud can map them
+# to source files (otherwise paths are absolute and resolve to nothing).
+relative_files = true
 source =
     pre_commit_hook/
 


### PR DESCRIPTION
## Summary

- **Dockerfile**: resolve merge conflict, switch to editable install (`-e`) so coverage records repo-relative paths instead of site-packages absolute paths
- **setup.cfg** `[coverage:run]`: add `relative_files = true` so SonarCloud can map paths in coverage.xml to actual source files
- **docker-compose.yml** `pytest` service: bind-mount `./coverage.xml:/src/coverage.xml` so the report surfaces on the host after the container run
- **Makefile** `docker-test`: pre-touch `coverage.xml` (prevents Docker creating it as a directory), add `-T` flag (non-TTY for CI), run pytest with `--cov-report xml:./coverage.xml` at repo root
- **ci.yml**: add `upload-artifact` step (name `test-results-3.14`, `if: always()`) after `make docker-test`; fix `coverage-report` from `coverage.xml` to `reports/coverage.xml` (the path sonar-scan-python downloads the artifact into)

Part of shared-standards#146. DO NOT MERGE.