### PR TITLE
fix: resolve SonarCloud blocker & critical findings

### DIFF
--- a/pre_commit_hook/generate_changelog.py
+++ b/pre_commit_hook/generate_changelog.py
@@ -78,7 +78,7 @@ class Collect:
                     )
 
 
-def main() -> int:
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate a Markdown changelog from YAML files.")
     parser.add_argument("filenames", nargs="*")
     parser.add_argument(
@@ -103,23 +103,31 @@ def main() -> int:
         help="rebuild changelog",
         choices=AVAILABLE_REBUILD_OPTION,
     )
-    parsed_args: argparse.Namespace = parser.parse_args()
-    collect_version = Collect(
-        changelog_folder=parsed_args.changelog_folder,
-        changelog_entry_available=CHANGELOG_ENTRY_AVAILABLE,
-        main_output_file=parsed_args.output_file,
-    )
-    collect_version.collect_versions()
-    if not collect_version.content:
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        parsed_args = _parse_args()
+        collect_version = Collect(
+            changelog_folder=parsed_args.changelog_folder,
+            changelog_entry_available=CHANGELOG_ENTRY_AVAILABLE,
+            main_output_file=parsed_args.output_file,
+        )
+        collect_version.collect_versions()
+        if not collect_version.content:
+            return 0
+        formatter = Formatter(changelog_entry_available=CHANGELOG_ENTRY_AVAILABLE)
+        formatter.generate(
+            archives_path=collect_version.changelog_folder_archive_path,
+            changelog_path=collect_version.changelog_path,
+            content_dict=collect_version.content,
+            rebuild=parsed_args.rebuild,
+        )
         return 0
-    formatter = Formatter(changelog_entry_available=CHANGELOG_ENTRY_AVAILABLE)
-    formatter.generate(
-        archives_path=collect_version.changelog_folder_archive_path,
-        changelog_path=collect_version.changelog_path,
-        content_dict=collect_version.content,
-        rebuild=parsed_args.rebuild,
-    )
-    return 0
+    except (NotADirectoryError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pre_commit_hook.generate_changelog import main
+
+
+class TestMain:
+    def test_returns_zero_when_no_content(self, tmp_path, mocker):
+        # GIVEN a changelog folder that exists but contains no YAML files
+        # WHEN main() is called
+        # THEN it returns 0 (success, nothing to generate)
+        changelog_folder = tmp_path / "changelog"
+        changelog_folder.mkdir()
+        mocker.patch("sys.argv", ["generate-changelog"])
+        mocker.patch.object(Path, "absolute", return_value=tmp_path)
+        result = main()
+        assert result == 0
+
+    def test_returns_one_on_missing_changelog_folder(self, tmp_path, mocker):
+        # GIVEN a project_path with no changelog subfolder
+        # WHEN main() is called
+        # THEN it returns 1 (NotADirectoryError is caught and converted to exit code 1)
+        mocker.patch("sys.argv", ["generate-changelog"])
+        mocker.patch.object(Path, "absolute", return_value=tmp_path)
+        result = main()
+        assert result == 1
+
+    def test_returns_one_on_invalid_yaml_key(self, tmp_path, mocker):
+        # GIVEN a YAML file with an unsupported section key
+        # WHEN main() is called
+        # THEN it returns 1 (ValueError is caught and converted to exit code 1)
+        changelog_folder = tmp_path / "changelog"
+        changelog_folder.mkdir()
+        (changelog_folder / "v1.0.0.yaml").write_text("invalid_key:\n  - entry\n")
+        mocker.patch("sys.argv", ["generate-changelog"])
+        mocker.patch.object(Path, "absolute", return_value=tmp_path)
+        result = main()
+        assert result == 1
+
+    def test_returns_zero_on_successful_generation(self, tmp_path, mocker):
+        # GIVEN a valid YAML changelog file
+        # WHEN main() is called
+        # THEN it returns 0 and the changelog.md is created
+        changelog_folder = tmp_path / "changelog"
+        changelog_folder.mkdir()
+        (changelog_folder / "v1.0.0.yaml").write_text("added:\n  - initial release\n")
+        mocker.patch("sys.argv", ["generate-changelog"])
+        mocker.patch.object(Path, "absolute", return_value=tmp_path)
+        result = main()
+        assert result == 0
+        assert (tmp_path / "changelog.md").exists()


### PR DESCRIPTION
## Summary

- Fixes SonarCloud BLOCKER `python:S3516` in `pre_commit_hook/generate_changelog.py`: the `main()` function previously always returned `0` on every code path (both the early-exit path when there is no content and the normal generation path), which Sonar flags as a function that always returns the same value.
- Fix: extract argument parsing into a `_parse_args()` helper and wrap `main()` body in `try/except (NotADirectoryError, ValueError)` so invalid input (missing changelog folder, unsupported YAML key) returns exit code `1`, while success paths return `0`. This aligns with pre-commit hook semantics — non-zero exit causes the hook to fail the commit.
- Add `tests/test_main.py` covering all four paths: empty changelog (exit 0), successful generation (exit 0), missing folder (exit 1), invalid YAML key (exit 1).

## Test plan

- [x] `make docker-test` (73/73 tests pass, 0 regressions)
- [x] New `test_main.py` — 4 tests covering both exit-code branches
- [ ] Verify SonarCloud analysis turns green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)