### PR TITLE
fix(packaging): raise python floor to 3.10 to match CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -27,7 +26,7 @@ keywords =
 
 [options]
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = true
 install_requires =
     ruamel.yaml


### PR DESCRIPTION
## Problem
`setup.cfg` declares `python_requires = >=3.9` plus a `Programming Language :: Python :: 3.9` classifier, but CI (`pythonpackage.yml`) only tests `[3.10, 3.11, 3.12, 3.13, 3.14]`. Python 3.9 is therefore neither supported nor tested — the declared floor is stale.

(Surfaced while auditing the fleet \"requires-python\" deep-gap: the other 4 flagged repos were false positives — sport-intelligence-hub declares it via Poetry, chrysa-lib declares it per sub-package, and linkendin-resume/server are applications, not packages. This repo was the only real item, and it was stale rather than missing.)

## Fix
- `python_requires`: `>=3.9` → `>=3.10`
- drop the stale `:: 3.9` classifier

Two-line metadata change; aligns the declared floor with the tested floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)