### PR TITLE
chore: add .dockerignore to slim build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Managed by conformity pass — keep build context lean
+.git
+.github
+node_modules
+__pycache__/
+*.py[cod]
+.venv
+venv
+.mypy_cache
+.ruff_cache
+.pytest_cache
+.env
+.env.*
+*.pem
+.DS_Store
+.vscode
+.idea


### PR DESCRIPTION
Automated conformity pass: adds .dockerignore next to the Dockerfile to exclude .git, node_modules, caches, venvs and secrets from the Docker build context.