### PR TITLE
chore: artifact isolation — non-root docker + caches out of tree + prod/dev stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,57 @@ tests/tmp/
 sys
 graphify
 graphify-out/
+
+# chrysa canonical .gitignore — source of truth
+# Source: chrysa/shared-standards/templates/gitignore.canonical
+# Appended (not overwritten) into each repo's .gitignore by project-init and
+# scripts/purge-artifacts.sh. Every entry here is a regenerable machine artifact,
+# never source. Repo-specific ignores live ABOVE the managed block in each repo.
+# ---8<--- chrysa:canonical:begin (managed — do not edit inside this block) --->8---
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+.venv/
+venv/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.benchmarks/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+.tox/
+
+# Node / frontend
+node_modules/
+.svelte-kit/
+.turbo/
+.vite/
+*.tsbuildinfo
+
+# Test / e2e output
+test-results/
+playwright-report/
+.playwright-mcp/
+
+# Local dev tooling caches (knowledge graph / code index)
+graphify-out/
+.codegraph/
+.import_linter_cache/
+
+# Claude Code local state
+.claude/worktrees/
+.claude/settings.local.json
+.claude/*.local.md
+
+# OS / editor
+.DS_Store
+Thumbs.db
+
+# ---8<--- chrysa:canonical:end --->8---

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,14 @@ FROM base AS application
 # instead of site-packages paths, which SonarCloud cannot map to source files.
 RUN pip install --quiet --editable .
 
+# Production runtime image: the package installed, no test/lint tooling.
+FROM application AS production
+
+# Developer image: production + test/lint/typecheck tooling and an editable install
+# so the mounted source is exercised directly. This is the target for local dev.
+FROM production AS dev
+RUN pip install --quiet -e ".[tests,flake8,mypy,pylint]"
+
 FROM application AS pytest
 RUN pip install --quiet -e ".[tests]"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,17 @@ x-app: &default-app
         dockerfile: Dockerfile
         cache_from:
             - &default-app-python-cache python:3.8-alpine
+    # Run bind-mount containers as the host user so tool output written into the
+    # mounted tree is owned by the developer, never root (chrysa artifact isolation).
+    user: "${UID:-1000}:${GID:-1000}"
+    # Keep every tool cache out of the mounted source tree and give a writable HOME.
+    environment:
+        HOME: /tmp
+        PYTHONPYCACHEPREFIX: /tmp/.toolcache/pycache
+        RUFF_CACHE_DIR: /tmp/.toolcache/ruff
+        MYPY_CACHE_DIR: /tmp/.toolcache/mypy
+        PYTEST_ADDOPTS: -p no:cacheprovider
+        COVERAGE_FILE: /tmp/.coverage
     command: bash
     volumes:
         - &default-app-volume-app ./pre_commit_hook:/src/pre_commit_hook


### PR DESCRIPTION
Enforces the shared-standards artifact-isolation rule.

- **Non-root bind-mount containers**: the shared `x-app` compose anchor now sets `user: "${UID:-1000}:${GID:-1000}"`, so tool output written into the mounted tree is owned by the developer, never root. Every service bind-mounts repo source, so all inherit it.
- **Tool caches redirected out of the mounted tree**: `HOME=/tmp`, `PYTHONPYCACHEPREFIX`, `RUFF_CACHE_DIR`, `MYPY_CACHE_DIR`, `PYTEST_ADDOPTS=-p no:cacheprovider`, plus `COVERAGE_FILE=/tmp/.coverage` (coverage otherwise writes `.coverage` into the root-owned `/src` image layer and fails as non-root).
- **Canonical .gitignore managed block** appended.
- **Multi-stage Dockerfile**: added named `production` and `dev` stages (base -> application -> production -> dev); `dev` layers test/lint/typecheck tooling on top of production.

Verified: `docker compose config` valid; `make docker-test` green (73 passed, 96.58% coverage) running as uid=1000 with the repo bind-mounted, proving non-root works. Full `docker build --target dev` was not fully reconfirmed (slow dep recompile) but the stage is present and syntactically sound.

Note: the pre-existing `quality` compose service targets the `pytest` build stage (no flake8), so the local pre-push `make lint` hook fails independently of this change — out of scope here.