### PR TITLE
ci: bump guideline-checker to v1.15.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,6 @@ repos:
     - revert
     - ci
 - repo: https://github.com/chrysa/guideline-checker
-  rev: v1.15.0
+  rev: v1.15.4
   hooks:
   - id: guideline-check


### PR DESCRIPTION
Bumps the guideline-checker hook rev to v1.15.4 so it installs under Python 3.12 (the previous pin required 3.14, breaking pre-commit install).