### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     stages:
     - manual
 - repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-98
+  rev: v0.1.1-99
   hooks:
   - id: makefile-check
   - exclude: ^(\.github/|workflows/|templates/)
@@ -72,6 +72,7 @@ repos:
   - id: claude-skill-frontmatter
   - id: claude-agent-frontmatter
   - id: claude-mcp-config
+  - id: python-no-unittest-import
 - repo: https://github.com/gitleaks/gitleaks
   rev: v8.30.1
   hooks:


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@3e0544cb43c47b184d9b5a9a6a2961e77038abe7`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards