### PR TITLE
chore: bump guideline-checker to v1.30.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,6 @@ repos:
     - revert
     - ci
 - repo: https://github.com/chrysa/guideline-checker
-  rev: v1.25.1
+  rev: v1.30.10
   hooks:
   - id: guideline-check


### PR DESCRIPTION
Bumps the guideline-checker pre-commit pin `v1.25.1` -> `v1.30.10`. Clears the fleet-wide false positive where the canonical 'no executable runtime' bullet was misread as a 'no exec()' rule and flagged every RegExp.exec()/.eval() call (chrysa/guideline-checker#305).