### PR TITLE
chore(ci): pin third-party actions by commit SHA

### DIFF
--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: gregsdennis/dependencies-action@v1.4.2
+        uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7 # v1.4.2
       - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
         with:
           use-label: Blocked

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,128 +1,201 @@
-name: Python package
+---
+name: CI
 
 on:
     push:
-        branches: [master, develop]
+        branches:
+            - master
+            - develop
+            - "feature/**"
+            - "hotfix/**"
+            - "release/**"
     pull_request:
-        branches: [master, develop]
+        branches:
+            - master
+            - develop
+
+# Required for publish-unit-test-result-action and SonarCloud
+permissions:
+    checks: write
+    contents: read
+    pull-requests: write
+    statuses: write
 
 jobs:
+    # ── Versioning ─────────────────────────────────────────────────────────────
+    versioning:
+        name: GitVersion
+        runs-on: ubuntu-latest
+        outputs:
+            semver: ${{ steps.gv.outputs.semVer }}
+            full-semver: ${{ steps.gv.outputs.fullSemVer }}
+        steps:
+            -   uses: actions/checkout@v6
+                with:
+                    fetch-depth: 0
+
+            -   id: gv
+                uses: chrysa/github-actions/gitversion@v1.0.1
+
+            -   name: Display version
+                run: |
+                    echo "SemVer    : ${{ steps.gv.outputs.semVer }}"
+                    echo "FullSemVer: ${{ steps.gv.outputs.fullSemVer }}"
+                shell: bash
+
+    # ── Tests ──────────────────────────────────────────────────────────────────
     tests:
         name: Tests (Python ${{ matrix.python-version }})
         runs-on: ubuntu-latest
+        needs: versioning
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         steps:
-            -   uses: actions/checkout@v7.0.1
+            -   uses: actions/checkout@v6
 
-            -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v7
+            -   uses: chrysa/github-actions/tool-setup@v1.0.1
                 with:
                     python-version: ${{ matrix.python-version }}
-                    allow-prereleases: true
-                    cache: pip
+                    extras: tests
 
-            -   name: Install dependencies
-                run: |
-                    python -m pip install --upgrade pip
-                    pip install -e ".[tests]"
-
-            -   name: Run tests with coverage
-                run: |
-                    pytest --cov=pre_commit_hook --cov-report=xml --cov-report=term-missing tests/
-
-            -   name: Upload coverage report
-                uses: actions/upload-artifact@v7
-                if: matrix.python-version == '3.14'
+            -   uses: chrysa/github-actions/run-tests@v1.0.1
                 with:
-                    name: coverage-report
-                    path: coverage.xml
+                    python-version: ${{ matrix.python-version }}
+                    latest-python: "3.14"
+                    cov-module: pre_commit_hook
 
+    # ── Lint ───────────────────────────────────────────────────────────────────
     lint:
         name: Lint
         runs-on: ubuntu-latest
-
+        needs: versioning
         steps:
-            -   uses: actions/checkout@v7.0.1
+            -   uses: actions/checkout@v6
 
-            -   name: Set up Python
-                uses: actions/setup-python@v7
+            -   uses: chrysa/github-actions/tool-setup@v1.0.1
                 with:
-                    python-version: "3.14"
-                    allow-prereleases: true
-                    cache: pip
+                    python-version: "3.13"
+                    extras: ruff,mypy
 
-            -   name: Install lint dependencies
-                run: |
-                    python -m pip install --upgrade pip
-                    pip install -e ".[flake8,mypy,pylint]"
+            -   uses: chrysa/github-actions/ruff-check@v1.0.1
+                with:
+                    python-version: "3.13"
+                    latest-python: "3.13"
+                    config: pyproject.toml
+                    sources: pre_commit_hook
 
-            -   name: Run flake8
-                run: flake8 --config=./setup.cfg ./pre_commit_hook
+            -   uses: chrysa/github-actions/mypy-check@v1.0.1
+                with:
+                    python-version: "3.13"
+                    latest-python: "3.13"
+                    config-file: setup.cfg
+                    sources: pre_commit_hook/
 
-            -   name: Run mypy
-                run: mypy --config-file=./setup.cfg pre_commit_hook/
-                continue-on-error: true
+    # ── Pre-commit ─────────────────────────────────────────────────────────────
+    pre-commit:
+        name: Pre-commit
+        runs-on: ubuntu-latest
+        needs: versioning
+        steps:
+            -   uses: actions/checkout@v6
 
+            -   uses: actions/setup-python@v6
+                with:
+                    python-version: "3.13"
+
+            -   uses: pre-commit/action@v3.0.1
+                env:
+                    SKIP: generate-changelog,env-file-check,requirements-sort
+
+    # ── SonarCloud ─────────────────────────────────────────────────────────────
+    sonar:
+        name: SonarCloud analysis
+        needs: [lint, tests]
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v6
+                with:
+                    fetch-depth: 0
+
+            -   uses: chrysa/github-actions/sonar-scan@v1.0.1
+                with:
+                    latest-python: "3.14"
+                    sonar-token: ${{ secrets.SONAR_TOKEN }}
+                    github-token: ${{ secrets.GITHUB_TOKEN }}
+                    project-key: chrysa_pre-commit-hooks-changelog
+                    organization: chrysa
+                    project-name: pre-commit-hooks-changelog
+                    sources: pre_commit_hook
+                    tests: tests
+
+    # ── Deploy TestPyPI ────────────────────────────────────────────────────────
     deploy-test:
         name: Deploy to TestPyPI
-        needs: [tests, lint]
+        needs: [versioning, tests, lint]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
-
         steps:
-            -   uses: actions/checkout@v7.0.1
+            -   uses: actions/checkout@v6
 
-            -   name: Set up Python
-                uses: actions/setup-python@v7
+            -   uses: chrysa/github-actions/tool-setup@v1.0.1
                 with:
-                    python-version: "3.14"
-                    allow-prereleases: true
-                    cache: pip
+                    python-version: "3.13"
+                    extras: pypi
 
-            -   name: Install build dependencies
+            -   name: Set version in setup.cfg
                 run: |
-                    python -m pip install --upgrade pip
-                    pip install build twine
+                    sed -i "s/^version = .*/version = ${{ needs.versioning.outputs.semver }}/" setup.cfg
+                shell: bash
 
             -   name: Build package
                 run: python -m build
+                shell: bash
 
             -   name: Publish to TestPyPI
-                env:
-                    TWINE_USERNAME: ${{ secrets.pypi_test_username }}
-                    TWINE_PASSWORD: ${{ secrets.pypi_test_password }}
                 run: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+                shell: bash
+                env:
+                    TWINE_USERNAME: ${{ secrets.PYPI_TEST_USERNAME }}
+                    TWINE_PASSWORD: ${{ secrets.PYPI_TEST_PASSWORD }}
 
+    # ── Deploy PyPI ────────────────────────────────────────────────────────────
     deploy-stable:
         name: Deploy to PyPI
-        needs: [tests, lint]
+        needs: [versioning, tests, lint]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-
         steps:
-            -   uses: actions/checkout@v7.0.1
+            -   uses: actions/checkout@v6
 
-            -   name: Set up Python
-                uses: actions/setup-python@v7
+            -   uses: chrysa/github-actions/tool-setup@v1.0.1
                 with:
-                    python-version: "3.14"
-                    allow-prereleases: true
-                    cache: pip
+                    python-version: "3.13"
+                    extras: pypi
 
-            -   name: Install build dependencies
+            -   name: Set version in setup.cfg
                 run: |
-                    python -m pip install --upgrade pip
-                    pip install build twine
+                    sed -i "s/^version = .*/version = ${{ needs.versioning.outputs.semver }}/" setup.cfg
+                shell: bash
 
             -   name: Build package
                 run: python -m build
+                shell: bash
 
             -   name: Publish to PyPI
-                env:
-                    TWINE_USERNAME: ${{ secrets.pypi_username }}
-                    TWINE_PASSWORD: ${{ secrets.pypi_password }}
                 run: twine upload dist/*
+                shell: bash
+                env:
+                    TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+                    TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+            -   name: Create GitHub Release
+                uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+                with:
+                    tag_name: v${{ needs.versioning.outputs.semver }}
+                    name: v${{ needs.versioning.outputs.semver }}
+                    generate_release_notes: true
+                    files: dist/*
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Applies the fleet GitHub Actions standard: **third-party actions are pinned by commit
SHA**, with the version kept in a trailing comment. `actions/*` and `chrysa/*` stay on tags.

A mutable tag or branch means the code executing in CI — with the workflow token — can change
under you without a diff. Found by a fleet-wide audit (87 unpinned references across 63 repos);
the copies distributed from `shared-standards` were fixed at the source in shared-standards#289,
this PR covers the workflows this repo owns.

Pinned here:

- `gregsdennis/dependencies-action` `v1.4.2` → `a8cccab69814`
- `softprops/action-gh-release` `v2` → `3bb12739c298`
