### PR TITLE
chore(ci): pin third-party actions by commit SHA

### DIFF
--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: gregsdennis/dependencies-action@v1.4.2
+        uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7 # v1.4.2
       - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
         with:
           use-label: Blocked

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -191,7 +191,7 @@ jobs:
                     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
             -   name: Create GitHub Release
-                uses: softprops/action-gh-release@v2
+                uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
                 with:
                     tag_name: v${{ needs.versioning.outputs.semver }}
                     name: v${{ needs.versioning.outputs.semver }}


### PR DESCRIPTION
Applies the fleet GitHub Actions standard: **third-party actions are pinned by commit
SHA**, with the version kept in a trailing comment. `actions/*` and `chrysa/*` stay on tags.

A mutable tag or branch means the code executing in CI — with the workflow token — can change
under you without a diff. Found by a fleet-wide audit (87 unpinned references across 63 repos);
the copies distributed from `shared-standards` were fixed at the source in shared-standards#289,
this PR covers the workflows this repo owns.

Pinned here:

- `gregsdennis/dependencies-action` `v1.4.2` → `a8cccab69814`
- `softprops/action-gh-release` `v2` → `3bb12739c298`
