### PR TITLE
ci: pin chrysa/github-actions at v1.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: chrysa/github-actions/sonar-scan-python@v1.1.3
+            - uses: chrysa/github-actions/sonar-scan-python@v1.6.0
               with:
                   python-version: "3.14"
                   sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,4 +18,4 @@ concurrency:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@v1.2.1
+    uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@v1.6.0

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,7 @@ jobs:
                     fetch-depth: 0
 
             -   id: gv
-                uses: chrysa/github-actions/gitversion@v1.0.1
+                uses: chrysa/github-actions/gitversion@v1.6.0
 
             -   name: Display version
                 run: |
@@ -55,12 +55,12 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   uses: chrysa/github-actions/tool-setup@v1.0.1
+            -   uses: chrysa/github-actions/tool-setup@v1.6.0
                 with:
                     python-version: ${{ matrix.python-version }}
                     extras: tests
 
-            -   uses: chrysa/github-actions/run-tests@v1.0.1
+            -   uses: chrysa/github-actions/run-tests@v1.6.0
                 with:
                     python-version: ${{ matrix.python-version }}
                     latest-python: "3.14"
@@ -74,19 +74,19 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   uses: chrysa/github-actions/tool-setup@v1.0.1
+            -   uses: chrysa/github-actions/tool-setup@v1.6.0
                 with:
                     python-version: "3.13"
                     extras: ruff,mypy
 
-            -   uses: chrysa/github-actions/ruff-check@v1.0.1
+            -   uses: chrysa/github-actions/ruff-check@v1.6.0
                 with:
                     python-version: "3.13"
                     latest-python: "3.13"
                     config: pyproject.toml
                     sources: pre_commit_hook
 
-            -   uses: chrysa/github-actions/mypy-check@v1.0.1
+            -   uses: chrysa/github-actions/mypy-check@v1.6.0
                 with:
                     python-version: "3.13"
                     latest-python: "3.13"
@@ -119,7 +119,7 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            -   uses: chrysa/github-actions/sonar-scan@v1.0.1
+            -   uses: chrysa/github-actions/sonar-scan@v1.6.0
                 with:
                     latest-python: "3.14"
                     sonar-token: ${{ secrets.SONAR_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   uses: chrysa/github-actions/tool-setup@v1.0.1
+            -   uses: chrysa/github-actions/tool-setup@v1.6.0
                 with:
                     python-version: "3.13"
                     extras: pypi
@@ -169,7 +169,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   uses: chrysa/github-actions/tool-setup@v1.0.1
+            -   uses: chrysa/github-actions/tool-setup@v1.6.0
                 with:
                     python-version: "3.13"
                     extras: pypi


### PR DESCRIPTION
Moves every `chrysa/github-actions` pin to **v1.6.0**.

An older tag keeps running an older gate. `v1.4.x` of `quality-gate-check.yml` invokes `make quality-gate-verify` with no guard and fails with `No rule to make target` on any repo that is not onboarded — a red check that says nothing about the code. `v1.6.0` also skips `pip install -e .` for a tooling-only `pyproject.toml` and only enables the npm cache when a lockfile exists.

Swept from `chrysa/shared-standards` (`scripts/github_actions_pin.py`).