### PR TITLE
chore(ci): pin third-party actions by commit SHA

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -105,7 +105,7 @@ jobs:
                 with:
                     python-version: "3.13"
 
-            -   uses: pre-commit/action@v3.0.1
+            -   uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
                 env:
                     SKIP: generate-changelog,env-file-check,requirements-sort
 


### PR DESCRIPTION
Applies the fleet GitHub Actions standard: **third-party actions are pinned by commit
SHA**, with the version kept in a trailing comment. `actions/*` and `chrysa/*` stay on tags.

A mutable tag or branch means the code executing in CI — with the workflow token — can change
under you without a diff. Found by a fleet-wide audit (87 unpinned references across 63 repos);
the copies distributed from `shared-standards` were fixed at the source in shared-standards#289,
this PR covers the workflows this repo owns.

Pinned here:

- `pre-commit/action` `v3.0.1` → `2c7b3805fd2a`
