### PR TITLE
ci: concurrency group and job timeouts (annexe CI-030, CI-031)

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -11,8 +11,8 @@
     paths:
       - .github/workflows/**
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   actionlint:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,8 +5,8 @@
       - ready_for_review
       - reopened
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   add-reviews:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,8 +3,8 @@
   workflow_call:
   workflow_dispatch:
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   labels:

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -15,8 +15,8 @@
   workflow_call:
   workflow_dispatch:
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check_dependencies:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,12 +31,6 @@ jobs:
         name: GitVersion
         runs-on: ubuntu-latest
         timeout-minutes: 30
-        timeout-minutes: 30
-        timeout-minutes: 30
-        timeout-minutes: 30
-        timeout-minutes: 30
-        timeout-minutes: 30
-        timeout-minutes: 30
         outputs:
             semver: ${{ steps.gv.outputs.semVer }}
             full-semver: ${{ steps.gv.outputs.fullSemVer }}
@@ -58,6 +52,7 @@ jobs:
     tests:
         name: Tests (Python ${{ matrix.python-version }})
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         needs: versioning
         strategy:
             fail-fast: false
@@ -81,6 +76,7 @@ jobs:
     lint:
         name: Lint
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         needs: versioning
         steps:
             -   uses: actions/checkout@v7
@@ -108,6 +104,7 @@ jobs:
     pre-commit:
         name: Pre-commit
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         needs: versioning
         steps:
             -   uses: actions/checkout@v7
@@ -125,6 +122,7 @@ jobs:
         name: SonarCloud analysis
         needs: [lint, tests]
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             -   uses: actions/checkout@v7
                 with:
@@ -146,6 +144,7 @@ jobs:
         name: Deploy to TestPyPI
         needs: [versioning, tests, lint]
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
         steps:
             -   uses: actions/checkout@v7
@@ -176,6 +175,7 @@ jobs:
         name: Deploy to PyPI
         needs: [versioning, tests, lint]
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         steps:
             -   uses: actions/checkout@v7

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -6,8 +6,8 @@
       - opened
       - synchronize
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update-body:


### PR DESCRIPTION
Applies the two deterministic rules of annexe [`CI-CD.md`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md):

- **CI-030** — every job declares `timeout-minutes:` (set to 30, raise it where the job legitimately runs longer). Without it a hung job holds a runner until the platform cap.
- **CI-031** — every PR-triggered workflow declares a concurrency group. Superseded PR runs are cancelled; **deploy and release workflows queue instead** (`cancel-in-progress: false`) — cancelling a deployment mid-flight is worse than queueing it.

The remaining findings (permissions, `secrets: inherit`, action pinning) are judgement calls and are reported by `scripts/ci_annexe_audit.py`, never guessed.